### PR TITLE
[FEAT/#9] 마이페이지에서 회원정보 조회해라

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':common:util')
     implementation project(':storage:db-core')
     implementation project(':client')
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/api/src/main/java/com/org/gunbbang/common/dto/ApiResponse.java
+++ b/api/src/main/java/com/org/gunbbang/common/dto/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.org.gunbbang.common.dto;
+
+import com.org.gunbbang.errorType.ErrorType;
+import com.org.gunbbang.errorType.SuccessType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String message;
+    private T data;
+
+    public static ApiResponse success(SuccessType success) {
+        return new ApiResponse<>(success.getHttpStatusCode(), success.getMessage());
+    }
+
+    public static <T> ApiResponse<T> success(SuccessType success, T data) {
+        return new ApiResponse<T>(success.getHttpStatusCode(), success.getMessage(), data);
+    }
+
+    public static ApiResponse error(ErrorType error) {
+        return new ApiResponse<>(error.getHttpStatusCode(), error.getMessage());
+    }
+
+    public static ApiResponse error(ErrorType error, String message) {
+        return new ApiResponse<>(error.getHttpStatusCode(), message);
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BreadTypeResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BreadTypeResponseDto.java
@@ -1,0 +1,39 @@
+package com.org.gunbbang.controller.DTO.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BreadTypeResponseDto {
+
+    private Long breadTypeId;
+
+    /**
+     * 글루텐프리,
+     * 비건빵,
+     * 넛프리,
+     * 저당 및 무설탕
+     */
+    private String breadTypeName;
+
+    private Boolean isGlutenFree; // 글루텐프리
+
+    private Boolean isVegan; // 비건빵
+
+    private Boolean isNutFree; // 넛프리
+
+    private Boolean isSugarFree; // 저당 및 무설탕
+
+    @Builder
+    public BreadTypeResponseDto(Long breadTypeId, String breadTypeName, boolean isGlutenFree, boolean isVegan, boolean isNutFree, boolean isSugarFree) {
+        this.breadTypeId = breadTypeId;
+        this.breadTypeName = breadTypeName;
+        this.isGlutenFree = isGlutenFree;
+        this.isVegan = isVegan;
+        this.isNutFree = isNutFree;
+        this.isSugarFree = isSugarFree;
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/MemberDetailResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/MemberDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.org.gunbbang.controller.DTO.response;
+
+import com.org.gunbbang.entity.BreadType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberDetailResponseDto {
+    private String memberNickname;
+    private String mainPurpose;
+    private BreadTypeResponseDto breadType;
+
+    @Builder
+    public MemberDetailResponseDto(String memberNickname, String mainPurpose, BreadTypeResponseDto breadType) {
+        this.memberNickname = memberNickname;
+        this.mainPurpose = mainPurpose;
+        this.breadType = breadType;
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/MemberController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.org.gunbbang.controller;
+
+import com.org.gunbbang.common.dto.ApiResponse;
+import com.org.gunbbang.controller.DTO.response.MemberDetailResponseDto;
+import com.org.gunbbang.errorType.SuccessType;
+import com.org.gunbbang.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<MemberDetailResponseDto> getMemberDetail(@RequestHeader("memberId") @Valid Long memberId){
+        MemberDetailResponseDto memberDetailResponseDto = memberService.getMemberDetail(memberId);
+        return ApiResponse.success(SuccessType.GET_MYPAGE_SUCCESS, memberDetailResponseDto);
+    }
+
+}

--- a/api/src/main/java/com/org/gunbbang/service/MemberService.java
+++ b/api/src/main/java/com/org/gunbbang/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.org.gunbbang.service;
+
+import com.org.gunbbang.NotFoundException;
+import com.org.gunbbang.controller.DTO.response.BreadTypeResponseDto;
+import com.org.gunbbang.controller.DTO.response.MemberDetailResponseDto;
+import com.org.gunbbang.entity.Member;
+import com.org.gunbbang.errorType.ErrorType;
+import com.org.gunbbang.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberDetailResponseDto getMemberDetail(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION));
+        BreadTypeResponseDto breadTypeResponseDto = BreadTypeResponseDto.builder()
+                .breadTypeId(member.getBreadTypeId().getBreadTypeId())
+                .breadTypeName(member.getBreadTypeId().getBreadTypeName())
+                .isVegan(member.getBreadTypeId().isVegan())
+                .isGlutenFree(member.getBreadTypeId().isGlutenFree())
+                .isSugarFree(member.getBreadTypeId().isSugarFree())
+                .isNutFree(member.getBreadTypeId().isNutFree())
+                .build();
+
+        return MemberDetailResponseDto.builder()
+                .memberNickname(member.getNickname())
+                .mainPurpose(member.getMainPurpose())
+                .breadType(breadTypeResponseDto)
+                .build();
+    }
+
+}

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
@@ -1,0 +1,38 @@
+package com.org.gunbbang.errorType;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessType {
+    /**
+     * 200 OK
+     */
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    GET_POST_LIST_SUCCESS(HttpStatus.OK, "게시물 리스트 조회에 성공했습니다."),
+    GET_POST_SUCCESS(HttpStatus.OK, "게시물 조회에 성공했습니다."),
+    GET_EMOTION_CALENDAR_SUCCESS(HttpStatus.OK, "감정 캘린더 조회에 성공했습니다."),
+    GET_EMOTION_SUCCESS(HttpStatus.OK, "감정 조회에 성공했습니다."),
+    GET_MYPAGE_SUCCESS(HttpStatus.OK, "마이페이지 조회에 성공했습니다."),
+    DELETE_IMAGE_SUCCESS(HttpStatus.OK, "이미지 삭제에 성공했습니다."),
+
+    /**
+     * 201 CREATED
+     */
+    SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료됐습니다."),
+    CREATE_BOARD_SUCCESS(HttpStatus.CREATED, "게시물 생성이 완료됐습니다."),
+    CREATE_EMOTION_SUCCESS(HttpStatus.CREATED, "감정 기록에 성공했습니다."),
+    CREATE_VOTE_SUCCESS(HttpStatus.CREATED, "투표가 완료됐습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}
+

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.org.gunbbang.repository;
+
+import com.org.gunbbang.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findById(Long memberId);
+}

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -50,7 +50,7 @@ INSERT INTO nutrient_type (nutrient_type_id, nutrient_type_name, is_ingredient_o
 
 -- member
 INSERT INTO member (email, password, platform_type, main_purpose, nickname, role, bread_type_id, nutrient_type_id)
-    VALUES ('example@naver.com', 'djfkskd!', 'NONE', '다이어트', '닉네임', 'ROLE_USER', 1, 3);
+    VALUES ('example@naver.com', 'djfkskd!', 'NONE', '다이어트', '닉네임', 'USER', 1, 3);
 
 -- category
 INSERT INTO category (category_id, category_name)


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feature/#9 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 마이페이지에 접근했을 때 회원의 이름, 해당 서비스를 가입한 주 목적, 원하는 빵 유형을 전달하는 api 입니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="847" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/33456be2-3ff9-4633-bed4-bc1eb5821608">

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 유저를 찾지 못하는 경우에 대한 에러처리를 service 단에서하는 것이 맞는지 아니면 컨트롤러 단에서 잡아야하는지 조언 부탁드립니다!