### PR TITLE
[FEAT] 건빵집 상세정보 조회 구현해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/BakeryController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeryController.java
@@ -1,0 +1,29 @@
+package com.org.gunbbang.controller;
+
+import com.org.gunbbang.common.dto.ApiResponse;
+import com.org.gunbbang.controller.DTO.response.BakeryDetailResponseDto;
+import com.org.gunbbang.controller.DTO.response.BakeryListResponseDto;
+import com.org.gunbbang.errorType.SuccessType;
+import com.org.gunbbang.service.BakeryService;
+import com.org.gunbbang.util.Security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bakery")
+public class BakeryController {
+    private final BakeryService bakeryService;
+
+    @GetMapping("/detail/{bakeryId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<BakeryDetailResponseDto> getMemberDetail(@PathVariable("bakeryId") @Valid Long bakeryId){
+        Long memberId = SecurityUtil.getLoginMemberId();
+        BakeryDetailResponseDto bakeryDetailResponseDto = bakeryService.getBakeryDetail(memberId, bakeryId);
+        return ApiResponse.success(SuccessType.GET_BAKERY_DETAIL_SUCCESS, bakeryDetailResponseDto);
+    }
+
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
@@ -1,0 +1,49 @@
+package com.org.gunbbang.controller.DTO.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BakeryDetailResponseDto {
+    private Long bakeryId;
+    private String bakeryName;
+    private String bakeryPicture;
+    private Boolean isHACCP;
+    private Boolean isVegan;
+    private Boolean isNonGMO;
+    private BreadTypeResponseDto breadTypeResponseDto;
+    private String firstNearStation;
+    private String secondNearStation;
+    private Boolean isBooked;
+    private int bookmarkCount;
+    private String homepage;
+    private String openingTime;
+    private String closedDay;
+    private String phoneNumber;
+    private List<MenuResponseDto> menuList;
+
+    @Builder
+    public BakeryDetailResponseDto(Long bakeryId, String bakeryName, String bakeryPicture, Boolean isHACCP, Boolean isVegan, Boolean isNonGMO, BreadTypeResponseDto breadTypeResponseDto, String firstNearStation, String secondNearStation, Boolean isBooked, int bookmarkCount, String homepage, String openingTime, String closedDay, String phoneNumber, List<MenuResponseDto> menuList) {
+        this.bakeryId = bakeryId;
+        this.bakeryName = bakeryName;
+        this.bakeryPicture = bakeryPicture;
+        this.isHACCP = isHACCP;
+        this.isVegan = isVegan;
+        this.isNonGMO = isNonGMO;
+        this.breadTypeResponseDto = breadTypeResponseDto;
+        this.firstNearStation = firstNearStation;
+        this.secondNearStation = secondNearStation;
+        this.isBooked = isBooked;
+        this.bookmarkCount = bookmarkCount;
+        this.homepage = homepage;
+        this.openingTime = openingTime;
+        this.closedDay = closedDay;
+        this.phoneNumber = phoneNumber;
+        this.menuList = menuList;
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/MenuResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/MenuResponseDto.java
@@ -1,0 +1,18 @@
+package com.org.gunbbang.controller.DTO.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MenuResponseDto {
+    private Long menuId;
+    private String menuName;
+    private int menuPrice;
+
+    @Builder
+    public MenuResponseDto(Long menuId, String menuName, int menuPrice) {
+        this.menuId = menuId;
+        this.menuName = menuName;
+        this.menuPrice = menuPrice;
+    }
+}

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
@@ -24,7 +24,7 @@ public enum ErrorType {
     NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다"),
     NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다"),
     INVALID_MULTIPART_EXTENSION_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다"),
-
+    INVALID_BAKERY_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 건빵집입니다"),
     NOT_FOUND_SAVE_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "이미지 저장에 실패했습니다"),
 
     /**

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
@@ -17,6 +17,8 @@ public enum SuccessType {
     GET_EMOTION_CALENDAR_SUCCESS(HttpStatus.OK, "감정 캘린더 조회에 성공했습니다."),
     GET_EMOTION_SUCCESS(HttpStatus.OK, "감정 조회에 성공했습니다."),
     GET_MYPAGE_SUCCESS(HttpStatus.OK, "마이페이지 조회에 성공했습니다."),
+    GET_BAKERY_LIST_SUCCESS(HttpStatus.OK, "건빵집 리스트 조회 성공"),
+    GET_BAKERY_DETAIL_SUCCESS(HttpStatus.OK, "건빵집 상세 페이지 조회 성공"),
     DELETE_IMAGE_SUCCESS(HttpStatus.OK, "이미지 삭제에 성공했습니다."),
 
     /**

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryCategoryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryCategoryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BakeryCategoryRepository extends JpaRepository<BakeryCategory,Long> {
     @Query("SELECT bc FROM BakeryCategory bc WHERE bc.categoryId IN (:categoryList) order by bc.bakeryId.bakeryId desc")

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -1,0 +1,10 @@
+package com.org.gunbbang.repository;
+
+import com.org.gunbbang.entity.Bakery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BakeryRepository extends JpaRepository<Bakery, Long> {
+    Optional<Bakery> findById(Long Id);
+}

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/MenuRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/MenuRepository.java
@@ -1,0 +1,11 @@
+package com.org.gunbbang.repository;
+
+import com.org.gunbbang.entity.Bakery;
+import com.org.gunbbang.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    List<Menu> findAllByBakeryId(Bakery bakeryId);
+}

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -75,3 +75,8 @@ VALUES (1,2,'1152-5','펄스브레드샵2','https://search.pstatic.net/common/?s
 -- bakery_category
 INSERT INTO bakery_category (bakery_id,category_id) values (1,2);
 INSERT INTO bakery_category (bakery_id,category_id) values (2,2);
+
+-- menu
+INSERT INTO menu (menu_name,menu_price,bakery_id) values ('소금빵',3000,1);
+INSERT INTO menu (menu_name,menu_price,bakery_id) values ('소금빵1',3000,1);
+INSERT INTO menu (menu_name,menu_price,bakery_id) values ('소금빵2',3000,1);


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#17 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- path variable을 통해 특정 건빵집의 상세 정보를 조회할 수 있는 api를 개발했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="892" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/ff425288-989f-420f-b312-1d666c7b580c">

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 유저의 액세스 토큰이 유효하지 않으면 404 forbidden 에러가 발생하는데 이거는 어디에서 커스텀 에러처리를 해줄 수 있는지 궁금합니다!
