### PR TITLE
[FIX] BakeryDetailResponseDto를 BaseBakeryResponseDto를 상속받는 클래스로 수정해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
@@ -2,8 +2,6 @@ package com.org.gunbbang.controller;
 
 import com.org.gunbbang.common.dto.ApiResponse;
 import com.org.gunbbang.controller.DTO.response.BakeryListResponseDto;
-import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryListResponseDTO;
-import com.org.gunbbang.controller.DTO.response.BestBakeryListResponseDTO;
 import com.org.gunbbang.errorType.SuccessType;
 import com.org.gunbbang.service.BakeryService;
 import com.org.gunbbang.util.Security.SecurityUtil;

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
@@ -1,6 +1,6 @@
 package com.org.gunbbang.controller.DTO.response;
 
-import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryListResponseDTO;
+import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryResponseDTO;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +11,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @SuperBuilder
-public class BakeryDetailResponseDto extends BaseBakeryListResponseDTO {
+public class BakeryDetailResponseDto extends BaseBakeryResponseDTO {
     private BreadTypeResponseDto breadTypeResponseDto;
     private String homepage;
     private String openingTime;

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryDetailResponseDto.java
@@ -1,45 +1,28 @@
 package com.org.gunbbang.controller.DTO.response;
 
+import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryListResponseDTO;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class BakeryDetailResponseDto {
-    private Long bakeryId;
-    private String bakeryName;
-    private String bakeryPicture;
-    private Boolean isHACCP;
-    private Boolean isVegan;
-    private Boolean isNonGMO;
+@SuperBuilder
+public class BakeryDetailResponseDto extends BaseBakeryListResponseDTO {
     private BreadTypeResponseDto breadTypeResponseDto;
-    private String firstNearStation;
-    private String secondNearStation;
-    private Boolean isBooked;
-    private int bookmarkCount;
     private String homepage;
     private String openingTime;
     private String closedDay;
     private String phoneNumber;
     private List<MenuResponseDto> menuList;
 
-    @Builder
     public BakeryDetailResponseDto(Long bakeryId, String bakeryName, String bakeryPicture, Boolean isHACCP, Boolean isVegan, Boolean isNonGMO, BreadTypeResponseDto breadTypeResponseDto, String firstNearStation, String secondNearStation, Boolean isBooked, int bookmarkCount, String homepage, String openingTime, String closedDay, String phoneNumber, List<MenuResponseDto> menuList) {
-        this.bakeryId = bakeryId;
-        this.bakeryName = bakeryName;
-        this.bakeryPicture = bakeryPicture;
-        this.isHACCP = isHACCP;
-        this.isVegan = isVegan;
-        this.isNonGMO = isNonGMO;
+        super(bakeryId, bakeryName, bakeryPicture, isHACCP, isVegan,
+                isNonGMO, firstNearStation, secondNearStation, isBooked, bookmarkCount);
         this.breadTypeResponseDto = breadTypeResponseDto;
-        this.firstNearStation = firstNearStation;
-        this.secondNearStation = secondNearStation;
-        this.isBooked = isBooked;
-        this.bookmarkCount = bookmarkCount;
         this.homepage = homepage;
         this.openingTime = openingTime;
         this.closedDay = closedDay;

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryListResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryListResponseDTO.java
@@ -1,13 +1,7 @@
 package com.org.gunbbang.controller.DTO.response.BaseDTO;
 
-import com.org.gunbbang.controller.DTO.response.BestBakeryListResponseDTO;
-import com.org.gunbbang.entity.Bakery;
-import com.org.gunbbang.entity.Member;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @SuperBuilder
-public class BaseBakeryListResponseDTO {
+public class BaseBakeryResponseDTO {
     private Long bakeryId;
     private String bakeryName;
     private String bakeryPicture;
@@ -18,7 +18,7 @@ public class BaseBakeryListResponseDTO {
     private Boolean isBooked;
     private int bookmarkCount;
 
-    public BaseBakeryListResponseDTO (
+    public BaseBakeryResponseDTO (
             Long bakeryId,
             String bakeryName,
             String bakeryPicture,

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BestBakeryListResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BestBakeryListResponseDTO.java
@@ -1,6 +1,6 @@
 package com.org.gunbbang.controller.DTO.response;
 
-import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryListResponseDTO;
+import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryResponseDTO;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -9,7 +9,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @SuperBuilder
-public class BestBakeryListResponseDTO extends BaseBakeryListResponseDTO {
+public class BestBakeryListResponseDTO extends BaseBakeryResponseDTO {
     private int reviewCount;
 
     public BestBakeryListResponseDTO(


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#36 -> dev
- closed #36

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- BakeryDetailResponseDto가 BaseBakeryResponseDto를 상송받도록 수정했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="835" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/ead4d045-12e0-470c-aa59-e842cf3472a0">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- baseDto를 추출해준 승하언냐 진짜 고맙습니다링!!