### PR TITLE
[FIX] BakeryListResponseDto를 BaseBakeryResponseDto를 상속받는 클래스로 수정해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
@@ -20,7 +20,7 @@ public class BakeriesController {
     private final BakeryService bakeryService;
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<BakeryListResponseDto>> getMemberDetail(@RequestParam("sort") @Valid String sort,
+    public ApiResponse<List<BakeryListResponseDto>> getBakeryList(@RequestParam("sort") @Valid String sort,
                                                                     @RequestParam("isHard") @Valid Boolean isHard,
                                                                     @RequestParam("isDessert") @Valid Boolean isDessert,
                                                                     @RequestParam("isBrunch") @Valid Boolean isBrunch){

--- a/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
@@ -26,6 +26,6 @@ public class BakeriesController {
                                                                     @RequestParam("isBrunch") @Valid Boolean isBrunch){
         Long memberId = SecurityUtil.getLoginMemberId();
         List<BakeryListResponseDto> bakeryListResponseDto = bakeryService.getBakeryList(memberId, sort,isHard,isDessert,isBrunch);
-        return ApiResponse.success(SuccessType.GET_MYPAGE_SUCCESS, bakeryListResponseDto);
+        return ApiResponse.success(SuccessType.GET_BAKERY_LIST_SUCCESS, bakeryListResponseDto);
     }
 }

--- a/api/src/main/java/com/org/gunbbang/controller/BakeryController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeryController.java
@@ -19,7 +19,7 @@ public class BakeryController {
 
     @GetMapping("/detail/{bakeryId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<BakeryDetailResponseDto> getMemberDetail(@PathVariable("bakeryId") @Valid Long bakeryId){
+    public ApiResponse<BakeryDetailResponseDto> getBakeryDetail(@PathVariable("bakeryId") @Valid Long bakeryId){
         Long memberId = SecurityUtil.getLoginMemberId();
         BakeryDetailResponseDto bakeryDetailResponseDto = bakeryService.getBakeryDetail(memberId, bakeryId);
         return ApiResponse.success(SuccessType.GET_BAKERY_DETAIL_SUCCESS, bakeryDetailResponseDto);

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryListResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryListResponseDto.java
@@ -1,37 +1,20 @@
 package com.org.gunbbang.controller.DTO.response;
 
+import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryResponseDTO;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class BakeryListResponseDto {
-    private Long bakeryId;
-    private String bakeryName;
-    private String bakeryPicture;
-    private Boolean isHACCP;
-    private Boolean isVegan;
-    private Boolean isNonGMO;
+@SuperBuilder
+public class BakeryListResponseDto extends BaseBakeryResponseDTO {
     private BreadTypeResponseDto breadTypeResponseDto;
-    private String firstNearStation;
-    private String secondNearStation;
-    private Boolean isBooked;
-    private int bookmarkCount;
 
-    @Builder
     public BakeryListResponseDto(Long bakeryId, String bakeryName, String bakeryPicture, Boolean isHACCP, Boolean isVegan, Boolean isNonGMO, BreadTypeResponseDto breadTypeResponseDto, String firstNearStation, String secondNearStation, Boolean isBooked, int bookmarkCount) {
-        this.bakeryId = bakeryId;
-        this.bakeryName = bakeryName;
-        this.bakeryPicture = bakeryPicture;
-        this.isHACCP = isHACCP;
-        this.isVegan = isVegan;
-        this.isNonGMO = isNonGMO;
+        super(bakeryId, bakeryName, bakeryPicture, isHACCP, isVegan,
+                isNonGMO, firstNearStation, secondNearStation, isBooked, bookmarkCount);
         this.breadTypeResponseDto = breadTypeResponseDto;
-        this.firstNearStation = firstNearStation;
-        this.secondNearStation = secondNearStation;
-        this.isBooked = isBooked;
-        this.bookmarkCount = bookmarkCount;
     }
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#38 -> dev
- closed #38

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- BakeryListResponseDto가 BaseBakeryResponseDto를 상속받도록 수정했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="881" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/26ca6510-9d0e-4f45-9fce-ec9adadf3893">

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- X
