### PR TITLE
[FEAT] 회원이 남긴 리뷰를 빵집 정보에 기반해 리스트 형태로 데이터를 받을 수 있는 기능을 구현해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryListReviewedByMemberDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BakeryListReviewedByMemberDto.java
@@ -1,0 +1,24 @@
+package com.org.gunbbang.controller.DTO.response;
+
+import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryResponseDTO;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
+public class BakeryListReviewedByMemberDto extends BaseBakeryResponseDTO {
+    private BreadTypeResponseDto breadTypeResponseDto;
+    private Long reviewId;
+    private String createdAt;
+
+    public BakeryListReviewedByMemberDto(Long bakeryId, String bakeryName, String bakeryPicture, Boolean isHACCP, Boolean isVegan, Boolean isNonGMO, BreadTypeResponseDto breadTypeResponseDto, String firstNearStation, String secondNearStation, Long reviewId, String createdAt) {
+        super(bakeryId, bakeryName, bakeryPicture, isHACCP, isVegan,
+                isNonGMO, firstNearStation, secondNearStation);
+        this.breadTypeResponseDto = breadTypeResponseDto;
+        this.reviewId = reviewId;
+        this.createdAt = createdAt;
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseBakeryResponseDTO.java
@@ -41,4 +41,15 @@ public class BaseBakeryResponseDTO {
          this.isBooked = isBooked;
          this.bookmarkCount = bookmarkCount;
     }
+
+    public BaseBakeryResponseDTO(Long bakeryId, String bakeryName, String bakeryPicture, Boolean isHACCP, Boolean isVegan, Boolean isNonGMO, String firstNearStation, String secondNearStation) {
+        this.bakeryId = bakeryId;
+        this.bakeryName = bakeryName;
+        this.bakeryPicture = bakeryPicture;
+        this.isHACCP = isHACCP;
+        this.isVegan = isVegan;
+        this.isNonGMO = isNonGMO;
+        this.firstNearStation = firstNearStation;
+        this.secondNearStation = secondNearStation;
+    }
 }

--- a/api/src/main/java/com/org/gunbbang/controller/MemberController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/MemberController.java
@@ -2,17 +2,21 @@ package com.org.gunbbang.controller;
 
 import com.org.gunbbang.common.dto.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.MemberTypesRequestDTO;
+import com.org.gunbbang.controller.DTO.response.BakeryListReviewedByMemberDto;
 import com.org.gunbbang.controller.DTO.response.MemberSignUpResponseDTO;
 import com.org.gunbbang.controller.DTO.response.MemberDetailResponseDto;
 import com.org.gunbbang.controller.DTO.response.MemberTypesResponseDTO;
 import com.org.gunbbang.errorType.SuccessType;
 import com.org.gunbbang.service.MemberService;
+import com.org.gunbbang.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import com.org.gunbbang.controller.DTO.request.MemberSignUpRequestDTO;
 import com.org.gunbbang.util.Security.SecurityUtil;
+
+import java.util.List;
 
 
 @RestController
@@ -21,6 +25,7 @@ import com.org.gunbbang.util.Security.SecurityUtil;
 public class MemberController {
 
     private final MemberService memberService;
+    private final ReviewService reviewService;
 
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
@@ -51,5 +56,12 @@ public class MemberController {
     public ApiResponse<MemberTypesResponseDTO> getMemberTypes() {
         Long memberId = SecurityUtil.getLoginMemberId();
         return ApiResponse.success(SuccessType.GET_MEMBER_TYPES_SUCCESS, memberService.getMemberTypes(memberId));
+    }
+
+    @GetMapping("/reviews")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<List<BakeryListReviewedByMemberDto>> getBakeryListReviewedByMember(){
+        Long memberId = SecurityUtil.getLoginMemberId();
+        return ApiResponse.success(SuccessType.GET_MEMBER_REVIEW_BAKERY_LIST_SUCCESS, reviewService.getBakeryListReviewedByMember(memberId));
     }
 }

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
@@ -19,6 +19,7 @@ public enum SuccessType {
     GET_MYPAGE_SUCCESS(HttpStatus.OK, "마이페이지 조회에 성공했습니다."),
     GET_BAKERY_LIST_SUCCESS(HttpStatus.OK, "건빵집 리스트 조회 성공"),
     GET_BAKERY_REVIEW_LIST_SUCCESS(HttpStatus.OK, "건빵집 리뷰 리스트 조회 성공"),
+    GET_MEMBER_REVIEW_BAKERY_LIST_SUCCESS(HttpStatus.OK, "회원이 리뷰한 빵집 리스트 조회 성공"),
     GET_BEST_BAKERIES_SUCCESS(HttpStatus.OK, "베스트 건빵집 리스트 조회 성공"),
     GET_BAKERY_DETAIL_SUCCESS(HttpStatus.OK, "건빵집 상세 페이지 조회 성공"),
     CANCEL_BOOKMARK_SUCCESS(HttpStatus.OK, "북마크 취소 성공"),

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.org.gunbbang.repository;
 
 import com.org.gunbbang.entity.Bakery;
+import com.org.gunbbang.entity.Member;
 import com.org.gunbbang.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review,Long> {
     Review save(Review review);
     List<Review> findAllByBakeryOrderByCreatedAtDesc(Bakery bakery);
+
+    List<Review> findAllByMemberOrderByCreatedAtDesc(Member member);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#25 -> dev
- closed #25

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회원이 남긴 리뷰를 빵집 정보에 기반해 리스트 형태로 데이터를 받을 수 있는 api를 개발했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="875" alt="스크린샷 2023-07-13 오후 12 09 09" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/2b24bd16-9216-4284-9e22-3c8a9b3d7e3e">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 현재 연결된 h2 데이터베이스에 빵집이 하나 뿐이라 리뷰가 모두 같은 빵집에 대해 작성 및 조회되고 있습니다 
- 리뷰는 최근에 등록된 순으로 정렬했습니다
