### PR TITLE
[FEAT] 리뷰 상세보기(리뷰 모아보기 상세) 기능 구현해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseReviewResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/BaseDTO/BaseReviewResponseDto.java
@@ -1,0 +1,26 @@
+package com.org.gunbbang.controller.DTO.response.BaseDTO;
+
+import com.org.gunbbang.controller.DTO.response.RecommendKeywordResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+public class BaseReviewResponseDto {
+    @NotNull
+    Long reviewId;
+    List<RecommendKeywordResponseDto> recommendKeywordList;
+    @NotNull
+    String reviewText;
+
+    public BaseReviewResponseDto(Long reviewId, String memberNickname, List<RecommendKeywordResponseDto> recommendKeywordList, String reviewText) {
+        this.reviewId = reviewId;
+        this.recommendKeywordList = recommendKeywordList;
+        this.reviewText = reviewText;
+    }
+}

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewDetailResponseDto.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewDetailResponseDto.java
@@ -12,15 +12,13 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @SuperBuilder
-public class ReviewResponseDto extends BaseReviewResponseDto {
+public class ReviewDetailResponseDto extends BaseReviewResponseDto {
     @NotNull
-    String memberNickname;
-    @NotNull
-    String createdAt;
+    Boolean isLike;
 
-    public ReviewResponseDto(Long reviewId, String memberNickname, List<RecommendKeywordResponseDto> recommendKeywordList, String reviewText, String createdAt) {
+    public ReviewDetailResponseDto(Long reviewId, String memberNickname, List<RecommendKeywordResponseDto> recommendKeywordList, String reviewText, Boolean isLike) {
         super(reviewId, memberNickname, recommendKeywordList, reviewText);
-        this.memberNickname = memberNickname;
-        this.createdAt = createdAt;
+        this.isLike = isLike;
     }
+
 }

--- a/api/src/main/java/com/org/gunbbang/controller/ReviewController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.org.gunbbang.controller;
 
 import com.org.gunbbang.common.dto.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.ReviewRequestDto;
+import com.org.gunbbang.controller.DTO.response.ReviewDetailResponseDto;
 import com.org.gunbbang.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import com.org.gunbbang.errorType.SuccessType;
@@ -19,11 +20,16 @@ public class ReviewController {
     @PostMapping(value = "/{bakeryId}")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse createReview(@PathVariable("bakeryId") @Valid final Long bakeryId, @RequestBody @Valid final ReviewRequestDto request) {
-        System.out.println(request.getIsLike());
         Long reviewId = reviewService.createReview(bakeryId,request);
         if(request.getIsLike()) {
             reviewService.createReviewRecommendKeyword(request.getKeywordList(), reviewId);
         }
         return ApiResponse.success(SuccessType.CREATE_REVIEW_SUCCESS);
+    }
+
+    @GetMapping(value="/{reviewId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<ReviewDetailResponseDto> getReviewedByMember(@PathVariable("reviewId") @Valid final Long reviewId) {
+        return ApiResponse.success(SuccessType.GET_REVIEW_DETAIL_MEMBER_SUCCESS, reviewService.getReviewedByMember(reviewId));
     }
 }

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/SuccessType.java
@@ -20,6 +20,7 @@ public enum SuccessType {
     GET_BAKERY_LIST_SUCCESS(HttpStatus.OK, "건빵집 리스트 조회 성공"),
     GET_BAKERY_REVIEW_LIST_SUCCESS(HttpStatus.OK, "건빵집 리뷰 리스트 조회 성공"),
     GET_MEMBER_REVIEW_BAKERY_LIST_SUCCESS(HttpStatus.OK, "회원이 리뷰한 빵집 리스트 조회 성공"),
+    GET_REVIEW_DETAIL_MEMBER_SUCCESS(HttpStatus.OK, "회원이 작성한 리뷰 조회 성공"),
     GET_BEST_BAKERIES_SUCCESS(HttpStatus.OK, "베스트 건빵집 리스트 조회 성공"),
     GET_BAKERY_DETAIL_SUCCESS(HttpStatus.OK, "건빵집 상세 페이지 조회 성공"),
     CANCEL_BOOKMARK_SUCCESS(HttpStatus.OK, "북마크 취소 성공"),

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
@@ -6,9 +6,12 @@ import com.org.gunbbang.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review,Long> {
     Review save(Review review);
+
+    Optional<Review> findByMember(Member member);
     List<Review> findAllByBakeryOrderByCreatedAtDesc(Bakery bakery);
 
     List<Review> findAllByMemberOrderByCreatedAtDesc(Member member);


### PR DESCRIPTION
## 🍞 PR 타입
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#26 -> dev
- closed #26

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 유저가 작성한 리뷰를 모아볼 때, 리뷰를 남긴 건빵집을 선택하면 리뷰 상세보기 페이지로 이동하는데, 이 때 필요한 정보를 전달하는 기능을 구현했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="844" alt="스크린샷 2023-07-13 오후 3 44 52" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/90b1083d-7340-4d38-893d-34c837f0563f">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- review도 baseDto를 생성해보았는데 확인 부탁드립니다!