### PR TITLE
[FEAT] CustomUserDetails에서 현재 접속한 회원의 빵유형, 주목적, 영양성분 공개 정보를 가져와라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/api/src/main/java/com/org/gunbbang/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -128,7 +128,10 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         CustomUserDetails userDetailsUser = new CustomUserDetails(
                 myMember.getEmail(),
                 myMember.getPassword(),
-                myMember.getMemberId());
+                myMember.getMemberId(),
+                myMember.getMainPurpose(),
+                myMember.getBreadType().getBreadTypeId(),
+                myMember.getNutrientType().getNutrientTypeId());
 
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(

--- a/api/src/main/java/com/org/gunbbang/login/CustomUserDetails.java
+++ b/api/src/main/java/com/org/gunbbang/login/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.org.gunbbang.login;
 
+import com.org.gunbbang.MainPurpose;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,10 +15,19 @@ public class CustomUserDetails implements UserDetails {
     private String password;
     private boolean enabled = true;
 
-    public CustomUserDetails(String username, String password, Long memberId) {
+    private MainPurpose mainPurpose;
+
+    private Long breadTypeId;
+
+    private Long nutrientTypeId;
+
+    public CustomUserDetails(String username, String password, Long memberId, MainPurpose mainPurpose, Long breadTypeId, Long nutrientTypeId) {
         this.username = username;
         this.password = password;
         this.memberId = memberId;
+        this.mainPurpose = mainPurpose;
+        this.breadTypeId = breadTypeId;
+        this.nutrientTypeId = nutrientTypeId;
     }
 
 
@@ -41,6 +51,18 @@ public class CustomUserDetails implements UserDetails {
 
     public Long getMemberId() {
         return memberId;
+    }
+
+    public MainPurpose getMainPurpose() {
+        return mainPurpose;
+    }
+
+    public Long getBreadTypeId() {
+        return breadTypeId;
+    }
+
+    public Long getNutrientTypeId() {
+        return nutrientTypeId;
     }
 
     @Override

--- a/api/src/main/java/com/org/gunbbang/login/service/CustomLoginService.java
+++ b/api/src/main/java/com/org/gunbbang/login/service/CustomLoginService.java
@@ -23,6 +23,10 @@ public class CustomLoginService implements UserDetailsService {
         return new CustomUserDetails(
                 member.getEmail(),
                 member.getPassword(),
-                member.getMemberId());
+                member.getMemberId(),
+                member.getMainPurpose(),
+                member.getBreadType().getBreadTypeId(),
+                member.getNutrientType().getNutrientTypeId()
+        );
     }
 }

--- a/api/src/main/java/com/org/gunbbang/util/Security/SecurityUtil.java
+++ b/api/src/main/java/com/org/gunbbang/util/Security/SecurityUtil.java
@@ -1,16 +1,46 @@
 package com.org.gunbbang.util.Security;
 
+import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.login.CustomUserDetails;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class SecurityUtil {
     public static Long getLoginMemberId() {
+        return getCustomUserDetails().getMemberId();
+    }
+
+    public static Long getLoginMemberBreadTypeId() {
+        return getCustomUserDetails().getBreadTypeId();
+    }
+
+    public static MainPurpose getLoginMemberMainPurpose() {
+        return getCustomUserDetails().getMainPurpose();
+    }
+
+    public static Long getLoginMemberNutrientTypeId() {
+        return getCustomUserDetails().getNutrientTypeId();
+    }
+
+    public static Map<String, Object> getLoginMemberInfo() {
+        Map<String, Object> memberInfoMap = new HashMap<>();
+        memberInfoMap.put("memberId", getLoginMemberId());
+        memberInfoMap.put("breadTypeId", getLoginMemberBreadTypeId());
+        memberInfoMap.put("mainPurpose", getLoginMemberMainPurpose());
+        memberInfoMap.put("nutrientTypeId", getLoginMemberNutrientTypeId());
+
+        return memberInfoMap;
+    }
+
+
+    private static CustomUserDetails getCustomUserDetails() {
         CustomUserDetails userInfo
                 = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        return userInfo.getMemberId();
+        return userInfo;
     }
+
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
feature/#49 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
커스텀한 UserDetails에서 회원의 빵유형 / 주목적 / 영양성분 공개 정보를 가져오도록 수정하였습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
