### PR TITLE
[FEAT] 이메일 중복체크 기능 추가 및 닉네임 중복체크 버그 해결

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/DTO/request/ValidateEmailRequestDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/request/ValidateEmailRequestDTO.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
-public class ValidateNicknameRequestDTO {
+public class ValidateEmailRequestDTO {
     @NotNull
-    private String nickname;
+    private String email;
 }

--- a/api/src/main/java/com/org/gunbbang/controller/ValidationController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ValidationController.java
@@ -1,10 +1,13 @@
 package com.org.gunbbang.controller;
 
+import com.org.gunbbang.controller.DTO.request.ValidateEmailRequestDTO;
 import com.org.gunbbang.controller.DTO.request.ValidateNicknameRequestDTO;
 import com.org.gunbbang.service.MemberService;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -16,8 +19,17 @@ public class ValidationController {
     private final MemberService memberService;
 
     @PostMapping("/validate/nickname")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void checkDuplicatedNickname(@RequestBody @Valid ValidateNicknameRequestDTO request) {
-        memberService.checkDuplicatedNickname(request.getNickname());
+        System.out.println("닉네임 ###" + request.getNickname().strip() + "###");
+        memberService.checkDuplicatedNickname(request.getNickname().strip());
+    }
+
+    @PostMapping("/validate/email")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void checkDuplicatedEmail (@RequestBody @Valid ValidateEmailRequestDTO request) {
+        System.out.println("이메일 ###" + request.getEmail().strip() + "###");
+        memberService.checkDuplicatedEmail(request.getEmail().strip());
     }
 
 }

--- a/api/src/main/java/com/org/gunbbang/service/MemberService.java
+++ b/api/src/main/java/com/org/gunbbang/service/MemberService.java
@@ -81,10 +81,10 @@ public class MemberService {
         ).orElseThrow();
 
         Member member = Member.builder()
-                .email(memberSignUpRequestDTO.getEmail())
-                .password(memberSignUpRequestDTO.getPassword())
+                .email(memberSignUpRequestDTO.getEmail().strip())
+                .password(memberSignUpRequestDTO.getPassword().strip())
                 .platformType(memberSignUpRequestDTO.getPlatformType())
-                .nickname(memberSignUpRequestDTO.getNickname())
+                .nickname(memberSignUpRequestDTO.getNickname().strip())
                 .role(Role.USER)
                 .breadType(breadType)
                 .nutrientType(nutrientType)
@@ -92,7 +92,7 @@ public class MemberService {
                 .build();
 
         member.passwordEncode(passwordEncoder);
-        memberRepository.save(member);
+        memberRepository.saveAndFlush(member);
 
         return MemberSignUpResponseDTO.builder()
                 .type(AuthType.SIGN_UP)
@@ -197,6 +197,12 @@ public class MemberService {
     public void checkDuplicatedNickname(String nickname) {
         if (memberRepository.findByNickname(nickname).isPresent()) {
             throw new BadRequestException(ErrorType.ALREADY_EXIST_NICKNAME_EXCEPTION);
+        }
+    }
+
+    public void checkDuplicatedEmail(String email) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new BadRequestException(ErrorType.ALREADY_EXIST_EMAIL_EXCEPTION);
         }
     }
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
feature/#52 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 이메일 중복체크 api 추가
- 이메일 및 닉네임 입력 시 앞뒤 공백 체거
- 회원가입 시 앞뒤 공백 체거

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
