### PR TITLE
[FEAT] 베스트 건빵집 조회 시 10개 모자랐을 때 랜덤으로 추가로 조회

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -163,13 +163,25 @@ public class BakeryService {
             return getResponseBakeries(foundMember, bestBakeries);
         }
 
-        List<Long> alreadyFoundBakeries = bestBakeries.stream().map(Bakery::getBakeryId).collect(Collectors.toList());
-        PageRequest restPageRequest = PageRequest.of(0, maxBestBakeryCount - bestBakeries.size());
+        List<Long> alreadyFoundBakeryIds = bestBakeries.stream().map(Bakery::getBakeryId).collect(Collectors.toList());
+        bestPageRequest = PageRequest.of(0, maxBestBakeryCount - bestBakeries.size());
         bestBakeries.addAll(bakeryRepository.findRestBakeriesByBreadTypeId(
                         foundMember.getBreadType(),
-                        alreadyFoundBakeries,
-                        restPageRequest));
+                        alreadyFoundBakeryIds,
+                        bestPageRequest));
 
+        if (bestBakeries.size() == maxBestBakeryCount) {
+            return getResponseBakeries(foundMember, bestBakeries);
+        }
+
+        alreadyFoundBakeryIds.addAll(
+                bestBakeries.stream().map(Bakery::getBakeryId).collect(Collectors.toList())
+        );
+
+        bestPageRequest = PageRequest.of(0, maxBestBakeryCount - bestBakeries.size());
+        bestBakeries.addAll(bakeryRepository.findRestBakeriesRandomly(
+                alreadyFoundBakeryIds,
+                bestPageRequest));
         return getResponseBakeries(foundMember, bestBakeries);
 
     }

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -46,4 +46,10 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long> {
             "INNER JOIN Member m ON bm.member.memberId = m.memberId " +
             "WHERE m.memberId = :memberId")
     List<Bakery> findBookMarkedBakeries(@Param("memberId") Long memberId);
+
+    @Query(value = "SELECT b FROM Bakery b " +
+            "WHERE b.bakeryId not in :alreadyFoundBakeries " +
+            "ORDER BY RAND() ")
+    List<Bakery> findRestBakeriesRandomly(List<Long> alreadyFoundBakeries,
+                                          PageRequest pageRequest);
 }

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -78,39 +78,83 @@ INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, ba
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (2,1,2,'1152-5','펄스브레드샵2','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+    VALUES (2,1,2,'1152-5','펄스브레드샵2','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
         '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 2, 9, 0, 5, 1, 3);
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (3, 1,3,'11-5','건대초코빵','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+    VALUES (3, 1,3,'11-5','건대초코빵','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
         '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 3, 5, 1, 1, 1, 2);
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (4,1,1,'52-5','비건비건','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+    VALUES (4,1,1,'52-5','비건비건','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
         '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 4, 6, 0, 1, 3, 2);
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (5,7,1,'52-5','저당빵만판다','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+    VALUES (5,7,1,'52-5','저당빵만판다','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
         '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 5, 14, 5, 4, 3, 2);
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (6,3,6,'5211-5','졸려','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+    VALUES (6,3,6,'5211-5','졸려','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
         '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 6, 7, 0, 7, 0, 0);
 INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
                     first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
                     book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
-VALUES (7,1,6,'51-5','졸빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
-        '경기도','일요일, 월요일','풍산역','https://www.idus.com/w/artist/1f6a0a08-7292-403d-8185-316f8d704d58/profile',true,false,true,'화~토 11:00 ~ 19:00',
+    VALUES (7,1,6,'51-5','졸빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
         '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (8,1,6,'51-5','졸빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (9,3,6,'51-5','졸빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (10,5,6,'51-5','졸빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (11,5,6,'51-5','빵빵빵','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (12,6,6,'51-5','흠냐링빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (13,7,6,'51-5','맛있는빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, bakery_name,bakery_picture, city, closed_day,
+                    first_near_station, homepage, is_haccp,is_nongmo, is_vegan, opening_hours, phone_number, second_near_station, state, town,
+                    book_mark_count, review_count, keyword_delicious_count, keyword_kind_count, keyword_special_count, keyword_zero_waste_count)
+    VALUES (14,3,6,'51-5','죽빵집','https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220526_91%2F1653554529250qdOYp_JPEG%2F0E35EAC3-F936-41C7-BEE4-645B83AED8B1.jpeg',
+        '경기도','일요일, 월요일','풍산역',null,true,false,true,'화~토 11:00 ~ 19:00',
+        '010-1111-1111','일산역','고양시','정발산동', 7, 8, 1, 7, 0, 0);
+
+
 
 -- bakery_category
 INSERT INTO bakery_category (bakery_id,category_id) values (1,2);


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
feature/#60 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
베스트 건빵집 조회 시
1. 베스트 건빵집 기준으로 조회하고
2. 현재 접속 중인 유저가 선택한 빵유형을 판매하는 건빵집 조회했을 때도
10개가 채워지지 않은 경우 랜덤 건빵집 채워서 10개로 보내주는 기능 구현

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
