### PR TITLE
[FIX] 건빵집 bakery service 로직에서 bookMark 판별 로직을 분리해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -93,10 +93,8 @@ public class BakeryService {
     }
 
     public BakeryDetailResponseDTO getBakeryDetail(Long memberId, Long bakeryId){
-        Boolean isBooked;
 
         Bakery bakery= bakeryRepository.findById(bakeryId).orElseThrow(()->new NotFoundException(ErrorType.NOT_FOUND_BAKERY_EXCEPTION));
-
         List<Menu> bakeryMenu = menuRepository.findAllByBakery(bakery);
 
         BreadTypeResponseDTO breadTypeResponseDto = BreadTypeResponseDTO.builder()
@@ -108,11 +106,7 @@ public class BakeryService {
                 .isSugarFree(bakery.getBreadType().getIsSugarFree())
                 .build();
 
-        if (bookMarkRepository.findByMemberAndBakery(memberRepository.findById(memberId).orElseThrow(()->new BadRequestException(ErrorType.REQUEST_VALIDATION_EXCEPTION)), bakery).isPresent()) {
-            isBooked = Boolean.TRUE;
-        } else {
-            isBooked = Boolean.FALSE;
-        }
+        Boolean isBookMark = isBooked(memberId, bakeryId);
 
         List<MenuResponseDTO> menuList = new ArrayList<>();
 
@@ -134,7 +128,7 @@ public class BakeryService {
                 .breadType(breadTypeResponseDto)
                 .firstNearStation(bakery.getFirstNearStation())
                 .secondNearStation(bakery.getSecondNearStation())
-                .isBooked(isBooked)
+                .isBooked(isBookMark)
                 .bookMarkCount(bakery.getBookMarkCount())
                 .homepage(bakery.getHomepage())
                 .address(bakery.getState()+" "+bakery.getCity()+" "+bakery.getTown()+" "+bakery.getAddressRest())

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -106,7 +105,7 @@ public class BakeryService {
                 .isSugarFree(bakery.getBreadType().getIsSugarFree())
                 .build();
 
-        Boolean isBookMark = isBooked(memberId, bakeryId);
+        Boolean isBookMark = isBookMarked(memberId, bakeryId);
 
         List<MenuResponseDTO> menuList = new ArrayList<>();
 
@@ -184,7 +183,7 @@ public class BakeryService {
     private List<BestBakeryListResponseDTO> getResponseBakeries(Member member, List<Bakery> bakeries) {
         List<BestBakeryListResponseDTO> responseDtoList = new ArrayList();
         for (Bakery bestBakery: bakeries) {
-            Boolean isBooked = isBooked(member.getMemberId(), bestBakery.getBakeryId());
+            Boolean isBooked = isBookMarked(member.getMemberId(), bestBakery.getBakeryId());
 
             BestBakeryListResponseDTO response = BestBakeryListResponseDTO.builder()
                     .bakeryId(bestBakery.getBakeryId())
@@ -209,7 +208,7 @@ public class BakeryService {
         List<Bakery> foundBakeries = bakeryRepository.findBakeryByBakeryName(bakeryName);
         List<BakeryListResponseDTO> bakeryListResponseDTOs = new ArrayList<>();
         for (Bakery foundBakery : foundBakeries) {
-            Boolean isBooked = isBooked(memberId, foundBakery.getBakeryId());
+            Boolean isBooked = isBookMarked(memberId, foundBakery.getBakeryId());
 
             BreadTypeResponseDTO breadTypeResponseDto = BreadTypeResponseDTO.builder()
                     .breadTypeId(foundBakery.getBreadType().getBreadTypeId())
@@ -247,7 +246,7 @@ public class BakeryService {
         return bakerySearchResponseDTO;
     }
 
-    private Boolean isBooked(Long memberId, Long bakeryId) {
+    private Boolean isBookMarked(Long memberId, Long bakeryId) {
         if (bookMarkRepository.findByMemberIdAndBakeryId(memberId, bakeryId).isPresent()) {
             return Boolean.TRUE;
         }

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -36,7 +36,7 @@ public class BakeryService {
         List<BakeryListResponseDTO> responseDtoList = new ArrayList();
         BakeryListResponseDTO bakeryListResponseDto;
         BreadTypeResponseDTO breadTypeResponseDto;
-        Boolean isBooked;
+        Boolean isBookMarked;
 
 
         if (Boolean.TRUE.equals(isHard)) {
@@ -66,11 +66,7 @@ public class BakeryService {
                     .isSugarFree(bakeryCategory.getBakery().getBreadType().getIsSugarFree())
                     .build();
 
-            if (bookMarkRepository.findByMemberAndBakery(memberRepository.findById(memberId).orElseThrow(()->new BadRequestException(ErrorType.REQUEST_VALIDATION_EXCEPTION)), bakeryCategory.getBakery()).isPresent()) {
-                isBooked = Boolean.TRUE;
-            } else {
-                isBooked = Boolean.FALSE;
-            }
+            isBookMarked = isBookMarked(memberId, bakeryCategory.getBakery().getBakeryId());
 
             bakeryListResponseDto = BakeryListResponseDTO.builder()
                     .bakeryId(bakeryCategory.getBakery().getBakeryId())
@@ -82,7 +78,7 @@ public class BakeryService {
                     .breadType(breadTypeResponseDto)
                     .firstNearStation(bakeryCategory.getBakery().getFirstNearStation())
                     .secondNearStation(bakeryCategory.getBakery().getSecondNearStation())
-                    .isBooked(isBooked)
+                    .isBooked(isBookMarked)
                     .bookMarkCount(bakeryCategory.getBakery().getBookMarkCount())
                     .build();
 

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -1,6 +1,5 @@
 package com.org.gunbbang.service;
 
-import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.NotFoundException;
 import com.org.gunbbang.controller.DTO.response.*;
 import com.org.gunbbang.entity.*;
@@ -48,7 +47,6 @@ public class BakeryService {
         if (Boolean.TRUE.equals(isBrunch)) {
             categoryIdList.add(categoryRepository.findByCategoryName("브런치류").orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION)));
         }
-
 
         if (sort.equals("reivew")) {
             bakeryCategoryList = bakeryCategoryRepository.findByBakeryCategoryIdAndReview(categoryIdList);


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#67 -> dev
- closed #67 

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 빵집 리스트에서 bookmark 여부에 대한 정보가 필요한 경우에 대한 로직을 합칠 수 있는 함수를 적용했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
