### PR TITLE
[FIX] 리뷰 좋아요 선택시 리뷰키워드를 선택하지 않아도 저장되는 로직을 수정해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/ReviewController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ReviewController.java
@@ -1,8 +1,10 @@
 package com.org.gunbbang.controller;
 
+import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.common.dto.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.ReviewRequestDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewDetailResponseDTO;
+import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import com.org.gunbbang.errorType.SuccessType;
@@ -22,6 +24,9 @@ public class ReviewController {
     public ApiResponse createReview(@PathVariable("bakeryId") @Valid final Long bakeryId, @RequestBody @Valid final ReviewRequestDTO request) {
         Long reviewId = reviewService.createReview(bakeryId, request);
         if (request.getIsLike()) {
+            if(request.getKeywordList().isEmpty()){
+                throw new BadRequestException(ErrorType.REQUEST_KEYWORDLIST_VALIDATION_EXCEPTION);
+            }
             reviewService.createReviewRecommendKeyword(request.getKeywordList(), reviewId);
         }
         return ApiResponse.success(SuccessType.CREATE_REVIEW_SUCCESS);

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
@@ -13,6 +13,7 @@ public enum ErrorType {
      * 400 BAD REQUEST
      */
     REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
+    REQUEST_KEYWORDLIST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "좋아요 선택시 추천 키워드를 하나 이상 선택해야 합니다"),
     INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 비밀번호입니다"),
     TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "만료된 토큰입니다"),
     ALREADY_BOOKMARKED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 북마크된 빵집입니다"),


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#77 -> dev
- closed #77

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 리뷰 좋아요 선택시 리뷰키워드를 선택하지 않아도 저장되는 로직을 수정

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
