### PR TITLE
[FIX] 베스트 베이커리 조회 시 무조건 10개 내려오도록 버그 수정하라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -106,6 +106,7 @@ public class BakeryService {
     public List<BestBakeryListResponseDTO> getBestBakeries() {
         Long memberId = SecurityUtil.getLoginMemberId();
         List<Long> alreadyFoundBakeryIds = new ArrayList<>();
+        alreadyFoundBakeryIds.add(Long.MAX_VALUE);
 
         Member foundMember = memberRepository
                 .findById(memberId)


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
fix/#87 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
베스트 베이커리 조회 시 무조건 10개 내려오도록 alreadyFoundBakeries에 Long 최대값 추가

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
