### PR TITLE
[FIX] 베스트 베이커리 조회 시 빈 배열만 나가는 에러를 해결하라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -107,6 +107,7 @@ public class BakeryService {
         Long memberId = SecurityUtil.getLoginMemberId();
         List<Long> alreadyFoundBakeryIds = new ArrayList<>();
         alreadyFoundBakeryIds.add(Long.MAX_VALUE);
+        System.out.println("alreadyFoundBakeryIds 값 확인: " + alreadyFoundBakeryIds);
 
         Member foundMember = memberRepository
                 .findById(memberId)
@@ -124,9 +125,11 @@ public class BakeryService {
             return getResponseBakeries(foundMember, bestBakeries);
         }
 
-        System.out.println("alreadyFoundBakeryIds 엠티 여부: " + alreadyFoundBakeryIds);
+        System.out.println("alreadyFoundBakeryIds 값 확인: " + alreadyFoundBakeryIds);
+        System.out.println("alreadyFoundBakeryIds 엠티 여부: " + alreadyFoundBakeryIds.isEmpty());
 
-        alreadyFoundBakeryIds = bestBakeries.stream().map(Bakery::getBakeryId).collect(Collectors.toList());
+        alreadyFoundBakeryIds.addAll(
+                bestBakeries.stream().map(Bakery::getBakeryId).collect(Collectors.toList()));
 
         log.info("빵유형 일치 베이커리 조회 시작");
         bestPageRequest = PageRequest.of(0, maxBestBakeryCount - bestBakeries.size());


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
fix/#87 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
베스트 베이커리 조회 시 빈 배열만 나가는 에러를 또ㅋㅋ 해결하라

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
