### PR TITLE
[BUG] 베스트 리뷰 조회 시 빈 배열로 나가는 에러 수정하라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -172,6 +172,9 @@ public class ReviewService {
     }
 
     public List<BestReviewListResponseDTO> getBestReviews(Long memberId) {
+        List<Long> alreadyFoundReviews = new ArrayList<>();
+        alreadyFoundReviews.add(Long.MAX_VALUE);
+
         PageRequest bestPageRequest = PageRequest.of(0, maxBestBakeryCount);
         Member foundMember = memberRepository
                 .findById(memberId)
@@ -186,7 +189,7 @@ public class ReviewService {
             return getBestReviewsListResponseDTO(memberId, bestReviews);
         }
 
-        List<Long> alreadyFoundReviews = bestReviews.stream().map(BestReviewDTO::getReviewId).collect(Collectors.toList());
+        alreadyFoundReviews = bestReviews.stream().map(BestReviewDTO::getReviewId).collect(Collectors.toList());
         PageRequest restPageRequest = PageRequest.of(0, maxBestBakeryCount - alreadyFoundReviews.size());
 
         bestReviews.addAll(


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
bug/#113 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
베스트 리뷰 조회 시 빈 배열로 나가는 에러 수정하라

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
