### PR TITLE
[FEAT] 빵집 이름 검색에 근처 역명/지역명으로 검색해도 해당되는 빵집을 찾을 수 있도록 기능 추가해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/SearchController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/SearchController.java
@@ -22,11 +22,9 @@ public class SearchController {
 
   @GetMapping("/bakeries")
   @SearchApiLog
-  public ApiResponse<BakerySearchResponseDTO> searchBakery(@RequestParam final String bakeryName) {
-    Long memberId = SecurityUtil.getLoginMemberId();
+  public ApiResponse<BakerySearchResponseDTO> searchBakery(@RequestParam final String searchTerm) {
     return ApiResponse.success(
-        SuccessType.SEARCH_BAKERIES_SUCCESS,
-        bakeryService.getBakeriesByName(bakeryName.strip(), memberId));
+        SuccessType.SEARCH_BAKERIES_SUCCESS, bakeryService.getBakeriesBySearch(searchTerm.trim()));
   }
 
   @GetMapping("/v2/bakeries")

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -197,6 +197,20 @@ public class BakeryService {
         bakeryListResponseDTOs.size(), bakeryListResponseDTOs);
   }
 
+  public BakerySearchResponseDTO getBakeriesBySearch(String searchTerm) {
+    if (searchTerm.isEmpty()) {
+      return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();
+    }
+    System.out.println("searchTerm = " + searchTerm);
+    List<String> searchWordList = new ArrayList<>(Arrays.asList(searchTerm.split("\\s+")));
+    List<Bakery> foundBakeries = bakeryRepository.findBakeryBySearch(searchWordList);
+    List<BakeryListResponseDTO> bakeryListResponseDTOs =
+        getBakeryListResponseDTOList(foundBakeries);
+
+    return BakeryMapper.INSTANCE.toBakerySearchResponseDTO(
+        bakeryListResponseDTOs.size(), bakeryListResponseDTOs);
+  }
+
   private List<BakeryListResponseDTO> getBakeryListResponseDTOList(List<Bakery> foundBakeries) {
     List<BakeryListResponseDTO> bakeryListResponseDTOs = new ArrayList<>();
 

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -186,19 +186,6 @@ public class BakeryService {
     return bestBakeries;
   }
 
-  //  public BakerySearchResponseDTO getBakeriesByName(String bakeryName, Long memberId) {
-  //    if (bakeryName.isEmpty()) {
-  //      return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();
-  //    }
-  //
-  //    List<Bakery> foundBakeries = bakeryRepository.findBakeryByBakeryName(bakeryName);
-  //    List<BakeryListResponseDTO> bakeryListResponseDTOs =
-  //        getBakeryListResponseDTOList(foundBakeries);
-  //
-  //    return BakeryMapper.INSTANCE.toBakerySearchResponseDTO(
-  //        bakeryListResponseDTOs.size(), bakeryListResponseDTOs);
-  //  }
-
   public BakerySearchResponseDTO getBakeriesBySearch(String searchTerm) {
     if (searchTerm.isEmpty()) {
       return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -7,6 +7,7 @@ import com.org.gunbbang.controller.DTO.response.BaseDTO.BaseBakeryResponseDTOV2;
 import com.org.gunbbang.entity.*;
 import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.repository.*;
+import com.org.gunbbang.service.specification.BakerySpecifications;
 import com.org.gunbbang.util.mapper.BakeryMapper;
 import com.org.gunbbang.util.mapper.BreadTypeMapper;
 import java.util.*;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -201,9 +203,16 @@ public class BakeryService {
     if (searchTerm.isEmpty()) {
       return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();
     }
-    System.out.println("searchTerm = " + searchTerm);
     List<String> searchWordList = new ArrayList<>(Arrays.asList(searchTerm.split("\\s+")));
-    List<Bakery> foundBakeries = bakeryRepository.findBakeryBySearch(searchWordList);
+
+    Specification<Bakery> spec = Specification.where(null);
+
+    for (String keyword : searchWordList) {
+      Specification<Bakery> keywordSpec = BakerySpecifications.searchBakery(keyword);
+      spec = spec.and(keywordSpec);
+    }
+
+    List<Bakery> foundBakeries = bakeryRepository.findAll(spec);
     List<BakeryListResponseDTO> bakeryListResponseDTOs =
         getBakeryListResponseDTOList(foundBakeries);
 

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -186,18 +186,18 @@ public class BakeryService {
     return bestBakeries;
   }
 
-  public BakerySearchResponseDTO getBakeriesByName(String bakeryName, Long memberId) {
-    if (bakeryName.isEmpty()) {
-      return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();
-    }
-
-    List<Bakery> foundBakeries = bakeryRepository.findBakeryByBakeryName(bakeryName);
-    List<BakeryListResponseDTO> bakeryListResponseDTOs =
-        getBakeryListResponseDTOList(foundBakeries);
-
-    return BakeryMapper.INSTANCE.toBakerySearchResponseDTO(
-        bakeryListResponseDTOs.size(), bakeryListResponseDTOs);
-  }
+  //  public BakerySearchResponseDTO getBakeriesByName(String bakeryName, Long memberId) {
+  //    if (bakeryName.isEmpty()) {
+  //      return BakerySearchResponseDTO.getEmptyBakerySearchResponseDTO();
+  //    }
+  //
+  //    List<Bakery> foundBakeries = bakeryRepository.findBakeryByBakeryName(bakeryName);
+  //    List<BakeryListResponseDTO> bakeryListResponseDTOs =
+  //        getBakeryListResponseDTOList(foundBakeries);
+  //
+  //    return BakeryMapper.INSTANCE.toBakerySearchResponseDTO(
+  //        bakeryListResponseDTOs.size(), bakeryListResponseDTOs);
+  //  }
 
   public BakerySearchResponseDTO getBakeriesBySearch(String searchTerm) {
     if (searchTerm.isEmpty()) {

--- a/api/src/main/java/com/org/gunbbang/service/specification/BakerySpecifications.java
+++ b/api/src/main/java/com/org/gunbbang/service/specification/BakerySpecifications.java
@@ -1,0 +1,20 @@
+package com.org.gunbbang.service.specification;
+
+import com.org.gunbbang.entity.Bakery;
+import org.springframework.data.jpa.domain.Specification;
+
+public class BakerySpecifications {
+  public static Specification<Bakery> searchBakery(String keyword) {
+    return (root, query, criteriaBuilder) -> {
+      String likePattern = "%" + keyword + "%";
+      return criteriaBuilder.or(
+          criteriaBuilder.like(root.get("state"), likePattern),
+          criteriaBuilder.like(root.get("city"), likePattern),
+          criteriaBuilder.like(root.get("town"), likePattern),
+          criteriaBuilder.like(root.get("addressRest"), likePattern),
+          criteriaBuilder.like(root.get("firstNearStation"), likePattern),
+          criteriaBuilder.like(root.get("secondNearStation"), likePattern),
+          criteriaBuilder.like(root.get("bakeryName"), likePattern));
+    };
+  }
+}

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -9,10 +9,12 @@ import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface BakeryRepository extends JpaRepository<Bakery, Long> {
+public interface BakeryRepository
+    extends JpaRepository<Bakery, Long>, JpaSpecificationExecutor<Bakery> {
   Optional<Bakery> findById(Long Id);
 
   // 나와 빵유형과 주목적이 일치하는 유저들이 북마크한 빵집중에 가장 북마크수가 높은 순대로 조회
@@ -41,10 +43,6 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long> {
 
   @Query(value = "SELECT b FROM Bakery b " + "WHERE b.bakeryName like %:bakeryName% ")
   List<Bakery> findBakeryByBakeryName(@Param("bakeryName") String bakeryName);
-
-  @Query(
-      "SELECT b FROM Bakery b WHERE CONCAT(b.state, ', ', b.city, ', ', b.town) Like :searchWord")
-  List<Bakery> findBakeryBySearch(@Param("searchWord") List<String> searcWordList);
 
   @Query(
       value =

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -43,6 +43,10 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long> {
   List<Bakery> findBakeryByBakeryName(@Param("bakeryName") String bakeryName);
 
   @Query(
+      "SELECT b FROM Bakery b WHERE CONCAT(b.state, ', ', b.city, ', ', b.town) Like :searchWord")
+  List<Bakery> findBakeryBySearch(@Param("searchWord") List<String> searcWordList);
+
+  @Query(
       value =
           "SELECT distinct b FROM Bakery b "
               + "INNER JOIN BookMark bm ON b.bakeryId = bm.bakery.bakeryId "


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feature/#138 -> dev
- closed #138

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 빵집 이름으로만 검색 가능했던 기능에 지역명과 가까운 역명으로 검색해도 찾을 수 있도록 기능을 추가했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/015201e4-2e95-4d57-96c8-ab764316266f)


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 작성해주신 매퍼 잘 사용했습니다
- Specification으로 가져온 값들을 and 조건으로 엮어 다중 키워드 검색 시 모두 포함되는 결과만 반환하도록 노력했습니다
  - 예를 들어 서울 강남이라고 검색하면 서울 or 강남이 아닌 서울 and 강남인 빵집이 나오도록 했습니다
