### PR TITLE
[FIX] 건빵집 작성된 리뷰 조회 API 리팩터링

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewListResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewListResponseDTO.java
@@ -19,10 +19,10 @@ public class ReviewListResponseDTO {
 
   @Builder
   public ReviewListResponseDTO(
-      Float tastePercent,
-      Float specialPercent,
-      Float kindPercent,
-      Float zeroPercent,
+      float tastePercent,
+      float specialPercent,
+      float kindPercent,
+      float zeroPercent,
       int totalReviewCount,
       List<ReviewResponseDTO> reviewList) {
     this.tastePercent = tastePercent;

--- a/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewListResponseDTO.java
+++ b/api/src/main/java/com/org/gunbbang/controller/DTO/response/ReviewListResponseDTO.java
@@ -1,7 +1,6 @@
 package com.org.gunbbang.controller.DTO.response;
 
 import java.util.List;
-import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,22 +9,22 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewListResponseDTO {
-  @NotNull Float tastePercent;
-  @NotNull Float specialPercent;
-  @NotNull Float kindPercent;
-  @NotNull Float zeroPercent;
-  @NotNull int totalReviewCount;
+  float deliciousPercent;
+  float specialPercent;
+  float kindPercent;
+  float zeroPercent;
+  long totalReviewCount;
   List<ReviewResponseDTO> reviewList;
 
   @Builder
   public ReviewListResponseDTO(
-      float tastePercent,
+      float deliciousPercent,
       float specialPercent,
       float kindPercent,
       float zeroPercent,
-      int totalReviewCount,
+      long totalReviewCount,
       List<ReviewResponseDTO> reviewList) {
-    this.tastePercent = tastePercent;
+    this.deliciousPercent = deliciousPercent;
     this.specialPercent = specialPercent;
     this.kindPercent = kindPercent;
     this.zeroPercent = zeroPercent;

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -121,7 +121,7 @@ public class ReviewService {
             .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_BAKERY_EXCEPTION));
     List<Review> reviewList = reviewRepository.findAllByBakeryOrderByCreatedAtDesc(bakery);
     List<ReviewResponseDTO> reviewListDto = new ArrayList<>();
-    long reviewCount;
+    long reviewCount = bakery.getReviewCount();
 
     for (Review review : reviewList) {
       List<RecommendKeywordResponseDTO> recommendKeywordList = new ArrayList<>();
@@ -148,8 +148,6 @@ public class ReviewService {
               .build());
     }
 
-    reviewCount = bakery.getReviewCount();
-
     return ReviewListResponseDTO.builder()
         .tastePercent(calculatorPercentage(reviewCount, bakery.getKeywordDeliciousCount()))
         .specialPercent(calculatorPercentage(reviewCount, bakery.getKeywordSpecialCount()))
@@ -160,7 +158,7 @@ public class ReviewService {
         .build();
   }
 
-  private Float calculatorPercentage(Long reviewCount, Long keywordCount) {
+  private float calculatorPercentage(long reviewCount, long keywordCount) {
     if (reviewCount == 0) {
       return 0f;
     }

--- a/api/src/main/java/com/org/gunbbang/util/mapper/RecommendKeywordMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/RecommendKeywordMapper.java
@@ -1,0 +1,22 @@
+package com.org.gunbbang.util.mapper;
+
+import com.org.gunbbang.controller.DTO.response.RecommendKeywordResponseDTO;
+import com.org.gunbbang.entity.ReviewRecommendKeyword;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface RecommendKeywordMapper {
+  RecommendKeywordMapper INSTANCE = Mappers.getMapper(RecommendKeywordMapper.class);
+
+  @Mapping(
+      source = "reviewRecommendKeyword.recommendKeyword.recommendKeywordId",
+      target = "recommendKeywordId")
+  @Mapping(
+      source = "reviewRecommendKeyword.recommendKeyword.keywordName",
+      target = "recommendKeywordName")
+  RecommendKeywordResponseDTO toRecommendKeywordResponseDTO(
+      ReviewRecommendKeyword reviewRecommendKeyword);
+}

--- a/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
@@ -2,7 +2,13 @@ package com.org.gunbbang.util.mapper;
 
 import com.org.gunbbang.BestReviewDTO;
 import com.org.gunbbang.controller.DTO.response.BestReviewListResponseDTO;
+import com.org.gunbbang.controller.DTO.response.RecommendKeywordResponseDTO;
+import com.org.gunbbang.controller.DTO.response.ReviewListResponseDTO;
+import com.org.gunbbang.controller.DTO.response.ReviewResponseDTO;
+import com.org.gunbbang.entity.Review;
+import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -14,4 +20,18 @@ public interface ReviewMapper {
       BestReviewDTO bestReviewDTO,
       String firstMaxRecommendKeyword,
       String secondMaxRecommendKeyword);
+
+  @Mapping(
+      target = "createdAt",
+      expression = "java( review.getCreatedAt().format(DateTimeFormatter.ofPattern(\"yy.MM.dd\") )")
+  ReviewResponseDTO toReviewResponseDTO(
+      Review review, List<RecommendKeywordResponseDTO> recommendKeywordResponseDTOList);
+
+  ReviewListResponseDTO toReviewListResponseDTO(
+      float tastePercent,
+      float specialPercent,
+      float kindPercent,
+      float zeroPercent,
+      int totalReviewCount,
+      List<ReviewResponseDTO> reviewResponseDTOList);
 }

--- a/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
@@ -21,17 +21,15 @@ public interface ReviewMapper {
       String firstMaxRecommendKeyword,
       String secondMaxRecommendKeyword);
 
-  @Mapping(
-      target = "createdAt",
-      expression = "java( review.getCreatedAt().format(DateTimeFormatter.ofPattern(\"yy.MM.dd\") )")
+  @Mapping(target = "memberNickname", expression = "java( review.getMember().getNickname() )")
   ReviewResponseDTO toReviewResponseDTO(
-      Review review, List<RecommendKeywordResponseDTO> recommendKeywordResponseDTOList);
+      Review review, String createdAt, List<RecommendKeywordResponseDTO> recommendKeywordList);
 
   ReviewListResponseDTO toReviewListResponseDTO(
-      float tastePercent,
+      float deliciousPercent,
       float specialPercent,
       float kindPercent,
       float zeroPercent,
-      int totalReviewCount,
-      List<ReviewResponseDTO> reviewResponseDTOList);
+      long totalReviewCount,
+      List<ReviewResponseDTO> reviewList);
 }

--- a/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
@@ -22,6 +22,7 @@ public interface ReviewMapper {
       String secondMaxRecommendKeyword);
 
   @Mapping(target = "memberNickname", expression = "java( review.getMember().getNickname() )")
+  @Mapping(source = "createdAt", target = "createdAt")
   ReviewResponseDTO toReviewResponseDTO(
       Review review, String createdAt, List<RecommendKeywordResponseDTO> recommendKeywordList);
 


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#146 -> dev
- closed #146

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- Mapper 적용하여 리팩토링 진행했습니다
- 엔티티에는 deliciousKeyword~로 정의되어있는데 ResponseDTO 내에는 taste라고 명시되어 있어 delicious로 통일했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/9cdb06a6-a7d6-4884-9d40-039102e4d125)

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- reviewService.java에서 해당 부분 리팩토링을 진행해도 로직이 깔끔한 것 같지 않아 고민입니다 더 좋은 방법이 있을지 궁금합니다
  ```
for (Review review : reviewList) {
      List<RecommendKeywordResponseDTO> recommendKeywordList = new ArrayList<>();
      if (review.getIsLike()) {
        List<ReviewRecommendKeyword> reviewRecommendKeywordList =
            reviewRecommendKeywordRepository.findAllByReview(review);
        for (ReviewRecommendKeyword reviewRecommendKeyword : reviewRecommendKeywordList) {
          recommendKeywordList.add(
              RecommendKeywordMapper.INSTANCE.toRecommendKeywordResponseDTO(
                  reviewRecommendKeyword));
        }
      }
      createdAt = review.getCreatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd"));
      reviewListDto.add(
          ReviewMapper.INSTANCE.toReviewResponseDTO(review, createdAt, recommendKeywordList));
    }
```
- 또한 Mapper를 사용하여 ReviewListResponseDTO에 percentage 계산값을 넘길 때 Percentage 4개 값을 넘기는게 나을지 이를 한번에 묶는 객체를 하나 더 만드는게 좋을지 고민입니다 조언 부탁드립니다!
