### PR TITLE
[FIX] 리뷰 작성하기 API 내에서 리뷰키워드 등록하는 로직 service 단에서 해결해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
@@ -1,12 +1,10 @@
 package com.org.gunbbang.controller;
 
 import com.org.gunbbang.AOP.annotation.BakeryIdApiLog;
-import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.common.dto.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.ReviewRequestDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewCreateResponseDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewDetailResponseDTO;
-import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.errorType.SuccessType;
 import com.org.gunbbang.service.ReviewService;
 import javax.validation.Valid;
@@ -27,12 +25,6 @@ public class ReviewsController {
       @PathVariable("bakeryId") final Long bakeryId,
       @RequestBody @Valid final ReviewRequestDTO request) {
     Long reviewId = reviewService.createReview(bakeryId, request);
-    if (request.getIsLike()) {
-      if (request.getKeywordList().isEmpty()) {
-        throw new BadRequestException(ErrorType.REQUEST_KEYWORDLIST_VALIDATION_EXCEPTION);
-      }
-      reviewService.createReviewRecommendKeyword(request.getKeywordList(), reviewId);
-    }
     return ApiResponse.success(
         SuccessType.CREATE_REVIEW_SUCCESS,
         ReviewCreateResponseDTO.builder().reviewId(reviewId).build());

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -1,7 +1,5 @@
 package com.org.gunbbang.service;
 
-import static com.org.gunbbang.util.ConstantVO.BLANK_SPACE;
-
 import com.org.gunbbang.CategoryType;
 import com.org.gunbbang.NotFoundException;
 import com.org.gunbbang.controller.DTO.response.*;
@@ -34,6 +32,7 @@ public class BakeryService {
   private final BakeryRepository bakeryRepository;
   private final MenuRepository menuRepository;
 
+  private final String BLANK_SPACE = " ";
   private final int maxBestBakeryCount = 10;
 
   public List<BakeryListResponseDTO> getBakeryList(

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -53,13 +53,17 @@ public class ReviewService {
                 .isLike(reviewRequestDto.getIsLike())
                 .reviewText(reviewRequestDto.getReviewText())
                 .build());
-    // 리뷰 작성되면 review count 증가
+
+    if (reviewRequestDto.getIsLike()) {
+      createReviewRecommendKeyword(reviewRequestDto.getKeywordList(), review.getReviewId());
+    }
+
     bakery.reviewCountChange(true);
     bakeryRepository.saveAndFlush(bakery);
     return review.getReviewId();
   }
 
-  public void createReviewRecommendKeyword(
+  private void createReviewRecommendKeyword(
       List<RecommendKeywordNameRequestDTO> keywordNameRequestDtoList, Long reviewId) {
     Review review =
         reviewRepository

--- a/api/src/main/java/com/org/gunbbang/util/ConstantVO.java
+++ b/api/src/main/java/com/org/gunbbang/util/ConstantVO.java
@@ -1,5 +1,0 @@
-package com.org.gunbbang.util;
-
-public class ConstantVO {
-  public static final String BLANK_SPACE = " ";
-}

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -183,7 +183,7 @@ INSERT INTO book_mark (bakery_id, member_id) values (5, 3);
 INSERT INTO book_mark (bakery_id, member_id) values (6, 4);
 INSERT INTO book_mark (bakery_id, member_id) values (7, 5);
 
--- -- review
+-- review
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (1, true, 'review_id: 1 | 제일최근 리뷰+좋아요+멤버빵유형 및 주목적 일치', 1, 2, '2023-07-13T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
@@ -195,7 +195,7 @@ INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, creat
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (5, true, 'review_id: 5 | 다섯+좋아요++멤버빵유형 및 주목적 일치', 5, 3, '2023-07-09T18:00:29.68338Z', null);
 
--- -- 여기까지 best 리뷰에서 조회되어야 하는 데이터
+-- 여기까지 best 리뷰에서 조회되어야 하는 데이터
 
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (6, true, 'review_id: 6 | 좋아요+빵유형만 일치 이거 나오면 안됨', 1, 4, '2023-07-11T18:00:29.68338Z', null);
@@ -223,8 +223,8 @@ INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, creat
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (16, false, 'review_id: 16 | 싫어요임 이거 나오면 안됨', 1, 4, '2023-07-12T18:00:29.68338Z', null);
 
--- -- 여기는 best+랜덤 리뷰 10개 했을때 모자라도 나오면 안되는 데이터
 
+-- 여기는 best+랜덤 리뷰 10개 했을때 모자라도 나오면 안되는 데이터
 -- ReviewRecommendKeyword
 INSERT INTO review_recommend_keyword (review_id, recommend_keyword_id) values (1, 1);  -- 빵집 1번
 INSERT INTO review_recommend_keyword (review_id, recommend_keyword_id) values (2, 1);  -- 빵집 1번


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#147 -> dev
- closed #147

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 리뷰키워드 등록은 좋아요인 리뷰에만 동작하는 기능이기 때문에 service단에서 처리하도록 로직을 수정해보았습니다!

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/7144e060-06c7-4422-bf55-e7c7a225c4e2)


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 리뷰 등록하기 API는 h2 데이터베이스에서는 리뷰 더미가 있을 경우에 제대로 동작하지 않는 것 같습니다.. 혹시라도 테스트 해보신다면 init sql에서 리뷰랑 리뷰키워드 더미는 제외하고 테스트하셔야 할 것 같습니다! 이건 앱잼때도 그랬는데 RDS에서는 발생하지 않았던 오류에요 ㅎㅎ
