### PR TITLE
[FIX] 마이페이지 조회 API 회원 정보 가져오는 로직 수정 및 리팩터링해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/MemberService.java
+++ b/api/src/main/java/com/org/gunbbang/service/MemberService.java
@@ -37,26 +37,19 @@ public class MemberService {
   private final NutrientTypeRepository nutrientTypeRepository;
 
   public MemberDetailResponseDTO getMemberDetail() {
-    Long currentMemberId = SecurityUtil.getLoginMemberId();
     String memberNickname = SecurityUtil.getLoginMemberNickname();
     MainPurpose memberMainPurpose = SecurityUtil.getLoginMemberMainPurpose();
     Long memberBreadTypeId = SecurityUtil.getLoginMemberBreadTypeId();
 
-    //    BreadTypeResponseDTO breadType =
-    //        BreadTypeResponseDTO.builder()
-    //            .breadTypeId(member.getBreadType().getBreadTypeId())
-    //            .breadTypeName(member.getBreadType().getBreadTypeName())
-    //            .isVegan(member.getBreadType().getIsVegan())
-    //            .isGlutenFree(member.getBreadType().getIsGlutenFree())
-    //            .isSugarFree(member.getBreadType().getIsSugarFree())
-    //            .isNutFree(member.getBreadType().getIsNutFree())
-    //            .build();
+    BreadType breadType =
+        breadTypeRepository
+            .findById(memberBreadTypeId)
+            .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION));
+    BreadTypeResponseDTO breadTypeResponseDTO =
+        BreadTypeMapper.INSTANCE.toBreadTypeResponseDTO(breadType);
 
-    return MemberDetailResponseDTO.builder()
-        .memberNickname(memberNickname)
-        .mainPurpose(memberMainPurpose)
-        //        .breadType(breadType)
-        .build();
+    return MemberTypeMapper.INSTANCE.toMemberDetailResponseDTO(
+        memberNickname, memberMainPurpose, breadTypeResponseDTO);
   }
 
   public MemberSignUpResponseDTO signUp(MemberSignUpRequestDTO memberSignUpRequestDTO) {

--- a/api/src/main/java/com/org/gunbbang/service/MemberService.java
+++ b/api/src/main/java/com/org/gunbbang/service/MemberService.java
@@ -38,25 +38,24 @@ public class MemberService {
 
   public MemberDetailResponseDTO getMemberDetail() {
     Long currentMemberId = SecurityUtil.getLoginMemberId();
+    String memberNickname = SecurityUtil.getLoginMemberNickname();
+    MainPurpose memberMainPurpose = SecurityUtil.getLoginMemberMainPurpose();
+    Long memberBreadTypeId = SecurityUtil.getLoginMemberBreadTypeId();
 
-    Member member =
-        memberRepository
-            .findById(currentMemberId)
-            .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_USER_EXCEPTION));
-    BreadTypeResponseDTO breadType =
-        BreadTypeResponseDTO.builder()
-            .breadTypeId(member.getBreadType().getBreadTypeId())
-            .breadTypeName(member.getBreadType().getBreadTypeName())
-            .isVegan(member.getBreadType().getIsVegan())
-            .isGlutenFree(member.getBreadType().getIsGlutenFree())
-            .isSugarFree(member.getBreadType().getIsSugarFree())
-            .isNutFree(member.getBreadType().getIsNutFree())
-            .build();
+    //    BreadTypeResponseDTO breadType =
+    //        BreadTypeResponseDTO.builder()
+    //            .breadTypeId(member.getBreadType().getBreadTypeId())
+    //            .breadTypeName(member.getBreadType().getBreadTypeName())
+    //            .isVegan(member.getBreadType().getIsVegan())
+    //            .isGlutenFree(member.getBreadType().getIsGlutenFree())
+    //            .isSugarFree(member.getBreadType().getIsSugarFree())
+    //            .isNutFree(member.getBreadType().getIsNutFree())
+    //            .build();
 
     return MemberDetailResponseDTO.builder()
-        .memberNickname(member.getNickname())
-        .mainPurpose(member.getMainPurpose())
-        .breadType(breadType)
+        .memberNickname(memberNickname)
+        .mainPurpose(memberMainPurpose)
+        //        .breadType(breadType)
         .build();
   }
 

--- a/api/src/main/java/com/org/gunbbang/util/mapper/MemberTypeMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/MemberTypeMapper.java
@@ -2,6 +2,7 @@ package com.org.gunbbang.util.mapper;
 
 import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.controller.DTO.response.BreadTypeResponseDTO;
+import com.org.gunbbang.controller.DTO.response.MemberDetailResponseDTO;
 import com.org.gunbbang.controller.DTO.response.MemberTypeResponseDTO;
 import com.org.gunbbang.controller.DTO.response.NutrientTypeResponseDTO;
 import org.mapstruct.Mapper;
@@ -17,4 +18,7 @@ public interface MemberTypeMapper {
       MainPurpose mainPurpose,
       BreadTypeResponseDTO breadType,
       NutrientTypeResponseDTO nutrientType);
+
+  MemberDetailResponseDTO toMemberDetailResponseDTO(
+      String memberNickname, MainPurpose mainPurpose, BreadTypeResponseDTO breadType);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#151 -> dev
- closed #151

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 마이페이지에서 필요한 회원 정보를 가져올 때 securityUtil을 사용하도록 코드를 수정했습니다
- Mapper 사용하여 리팩토링 진행했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="761" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/14ffa24b-d8a3-45ca-bd59-bbc17f2f8549">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 지금 멤버와 관련되서 사용되는 Mapper이름이 MemberType Mapper인데 여기 안에 memberdetailDTO 반환하는 코드도 추가해서 MemberMapper로 이름 변경하는건 어떠신지 궁금합니다! 괜찮다고하시면 제가 적용하고 push할게요 ^0^
