### PR TITLE
[FIX] ReviewService에서 리뷰 상세조회 시 추천 키워드 가져오는 로직은 함수를 사용하고 리턴 값에 Mapper 적용해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/MemberService.java
+++ b/api/src/main/java/com/org/gunbbang/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.org.gunbbang.service;
 
 import com.org.gunbbang.BadRequestException;
+import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.NotFoundException;
 import com.org.gunbbang.common.AuthType;
 import com.org.gunbbang.controller.DTO.request.MemberSignUpRequestDTO;

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -95,26 +95,9 @@ public class ReviewService {
             .findById(reviewId)
             .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_REVIEW_EXCEPTION));
     if (currentMemberId.equals(review.getMember().getMemberId())) {
-      List<RecommendKeywordResponseDTO> recommendKeywordList = new ArrayList<>();
-      if (review.getIsLike()) {
-        List<ReviewRecommendKeyword> reviewRecommendKeywordList =
-            reviewRecommendKeywordRepository.findAllByReview(review);
-        for (ReviewRecommendKeyword reviewRecommendKeyword : reviewRecommendKeywordList) {
-          recommendKeywordList.add(
-              RecommendKeywordResponseDTO.builder()
-                  .recommendKeywordId(
-                      reviewRecommendKeyword.getRecommendKeyword().getRecommendKeywordId())
-                  .recommendKeywordName(
-                      reviewRecommendKeyword.getRecommendKeyword().getKeywordName())
-                  .build());
-        }
-      }
-      return ReviewDetailResponseDTO.builder()
-          .reviewId(review.getReviewId())
-          .isLike(review.getIsLike())
-          .recommendKeywordList(recommendKeywordList)
-          .reviewText(review.getReviewText())
-          .build();
+      List<RecommendKeywordResponseDTO> recommendKeywordList =
+          getReCommendKeywordListResponseDTO(review);
+      return ReviewMapper.INSTANCE.toReviewDetailResponseDTO(review, recommendKeywordList);
     } else {
       throw new BadRequestException(ErrorType.REQUEST_VALIDATION_EXCEPTION);
     }

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -138,11 +138,8 @@ public class ReviewService {
     if (review.getIsLike()) {
       List<ReviewRecommendKeyword> reviewRecommendKeywordList =
           reviewRecommendKeywordRepository.findAllByReview(review);
-      for (ReviewRecommendKeyword reviewRecommendKeyword : reviewRecommendKeywordList) {
-        recommendKeywordList.add(
-            RecommendKeywordMapper.INSTANCE.toRecommendKeywordResponseDTO(reviewRecommendKeyword));
-      }
-      return recommendKeywordList;
+      return RecommendKeywordMapper.INSTANCE.toRecommendKeywordListResponseDTO(
+          reviewRecommendKeywordList);
     }
     return recommendKeywordList;
   }

--- a/api/src/main/java/com/org/gunbbang/util/mapper/RecommendKeywordMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/RecommendKeywordMapper.java
@@ -2,6 +2,8 @@ package com.org.gunbbang.util.mapper;
 
 import com.org.gunbbang.controller.DTO.response.RecommendKeywordResponseDTO;
 import com.org.gunbbang.entity.ReviewRecommendKeyword;
+import java.util.List;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -11,12 +13,12 @@ import org.mapstruct.factory.Mappers;
 public interface RecommendKeywordMapper {
   RecommendKeywordMapper INSTANCE = Mappers.getMapper(RecommendKeywordMapper.class);
 
-  @Mapping(
-      source = "reviewRecommendKeyword.recommendKeyword.recommendKeywordId",
-      target = "recommendKeywordId")
-  @Mapping(
-      source = "reviewRecommendKeyword.recommendKeyword.keywordName",
-      target = "recommendKeywordName")
+  @Mapping(source = "recommendKeyword.recommendKeywordId", target = "recommendKeywordId")
+  @Mapping(source = "recommendKeyword.keywordName", target = "recommendKeywordName")
   RecommendKeywordResponseDTO toRecommendKeywordResponseDTO(
       ReviewRecommendKeyword reviewRecommendKeyword);
+
+  @IterableMapping(elementTargetType = RecommendKeywordResponseDTO.class)
+  List<RecommendKeywordResponseDTO> toRecommendKeywordListResponseDTO(
+      List<ReviewRecommendKeyword> recommendKeywords);
 }

--- a/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
+++ b/api/src/main/java/com/org/gunbbang/util/mapper/ReviewMapper.java
@@ -1,10 +1,7 @@
 package com.org.gunbbang.util.mapper;
 
 import com.org.gunbbang.BestReviewDTO;
-import com.org.gunbbang.controller.DTO.response.BestReviewListResponseDTO;
-import com.org.gunbbang.controller.DTO.response.RecommendKeywordResponseDTO;
-import com.org.gunbbang.controller.DTO.response.ReviewListResponseDTO;
-import com.org.gunbbang.controller.DTO.response.ReviewResponseDTO;
+import com.org.gunbbang.controller.DTO.response.*;
 import com.org.gunbbang.entity.Review;
 import com.org.gunbbang.util.RecommendKeywordPercentage;
 import java.util.List;
@@ -35,4 +32,7 @@ public interface ReviewMapper {
       RecommendKeywordPercentage recommendKeywordPercentage,
       long totalReviewCount,
       List<ReviewResponseDTO> reviewList);
+
+  ReviewDetailResponseDTO toReviewDetailResponseDTO(
+      Review review, List<RecommendKeywordResponseDTO> recommendKeywordList);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#153 -> dev
- closed #153

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 리뷰 상세조회 시 추천 키워드를 가져오는 로직을 이전에 함수로 분리했어서 그 함수를 사용하도록 수정했습니다
- 리턴 값은 ReviewMapper를 사용하여 반환하도록 수정했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="755" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/7a68e257-4b13-4636-90ee-9e57cea5e876">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
