### PR TITLE
[FEAT] 건빵집 리스트 조회 API 수정사항 반영하여 추가 기능 구현해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/BakeriesController.java
@@ -25,13 +25,13 @@ public class BakeriesController {
   @GetMapping("")
   @ResponseStatus(HttpStatus.OK)
   public ApiResponse<List<BakeryListResponseDTO>> getBakeryList(
-      @RequestParam("sort") String sort,
+      @RequestParam("sortingOption") String sortingOption,
+      @RequestParam("personalFilter") boolean personalFilter,
       @RequestParam("isHard") boolean isHard,
       @RequestParam("isDessert") boolean isDessert,
       @RequestParam("isBrunch") boolean isBrunch) {
-    Long memberId = SecurityUtil.getLoginMemberId();
     List<BakeryListResponseDTO> bakeryListResponseDto =
-        bakeryService.getBakeryList(memberId, sort, isHard, isDessert, isBrunch);
+        bakeryService.getBakeryList(sortingOption, personalFilter, isHard, isDessert, isBrunch);
     return ApiResponse.success(SuccessType.GET_BAKERY_LIST_SUCCESS, bakeryListResponseDto);
   }
 

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -36,43 +36,65 @@ public class BakeryService {
   private final int maxBestBakeryCount = 10;
 
   public List<BakeryListResponseDTO> getBakeryList(
-      String sort, boolean isHard, boolean isDessert, boolean isBrunch) {
+      String sortingOption,
+      boolean personalFilter,
+      boolean isHard,
+      boolean isDessert,
+      boolean isBrunch) {
     List<Category> categoryList = getCategoryList(isHard, isDessert, isBrunch);
-    List<BakeryListResponseDTO> responseDtoList = new ArrayList<>();
-    BreadTypeResponseDTO breadType;
+    List<BakeryListResponseDTO> responseDtoList;
     List<Bakery> bakeryList;
 
     if (categoryList.isEmpty()) {
       Sort sortOption =
-          sort.equals("review")
+          sortingOption.equals("review")
               ? Sort.by(Sort.Direction.DESC, "reviewCount")
               : Sort.by(Sort.Direction.DESC, "bakeryId");
       bakeryList = bakeryRepository.findAll(sortOption);
-      for (Bakery bakery : bakeryList) {
-        breadType = getBreadType(bakery);
-        BakeryListResponseDTO bakeryListResponseDto = getBakeryResponseDTO(bakery, breadType);
-        responseDtoList.add(bakeryListResponseDto);
-      }
+      responseDtoList = getBakeryListResponseDTOList(bakeryList);
       return responseDtoList;
     }
 
-    if (sort.equals("review")) {
+    if (sortingOption.equals("review")) {
       bakeryList = bakeryRepository.findBakeriesByCategoryAndReview(categoryList);
-      for (Bakery bakery : bakeryList) {
-        breadType = getBreadType(bakery);
-        BakeryListResponseDTO bakeryListResponseDto = getBakeryResponseDTO(bakery, breadType);
-        responseDtoList.add(bakeryListResponseDto);
-      }
+      responseDtoList = getBakeryListResponseDTOList(bakeryList);
       return responseDtoList;
     }
 
     bakeryList = bakeryRepository.findBakeriesByCategory(categoryList);
-    for (Bakery bakery : bakeryList) {
-      breadType = getBreadType(bakery);
-      BakeryListResponseDTO bakeryListResponseDto = getBakeryResponseDTO(bakery, breadType);
-      responseDtoList.add(bakeryListResponseDto);
-    }
+    responseDtoList = getBakeryListResponseDTOList(bakeryList);
     return responseDtoList;
+  }
+
+  private List<Category> getCategoryList(boolean isHard, boolean isDessert, boolean isBrunch) {
+    List<Category> categoryList = new ArrayList<>();
+
+    Map<CategoryType, Boolean> categoryMap = new HashMap<>();
+    categoryMap.put(CategoryType.HARD_BREAD, isHard);
+    categoryMap.put(CategoryType.DESSERT, isDessert);
+    categoryMap.put(CategoryType.BRUNCH, isBrunch);
+
+    for (Map.Entry<CategoryType, Boolean> entry : categoryMap.entrySet()) {
+      if (entry.getValue()) { // true인 값만 해당되어 category에 추가된다
+        Category category =
+            categoryRepository
+                .findByCategoryName(entry.getKey().getName())
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION));
+        categoryList.add(category);
+      }
+    }
+
+    if (categoryList.isEmpty()) { // 카테고리가를 선택하지 않은 경우에는 모두 추가된다
+      for (CategoryType categoryType : CategoryType.values()) {
+        Category category =
+            categoryRepository
+                .findByCategoryName(categoryType.getName())
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION));
+        categoryList.add(category);
+      }
+    }
+
+    return categoryList;
   }
 
   public BakeryDetailResponseDTO getBakeryDetail(Long memberId, Long bakeryId) {
@@ -229,34 +251,6 @@ public class BakeryService {
     return false;
   }
 
-  private BreadTypeResponseDTO getBreadType(Bakery bakery) {
-    return BreadTypeResponseDTO.builder()
-        .breadTypeId(bakery.getBreadType().getBreadTypeId())
-        .breadTypeName(bakery.getBreadType().getBreadTypeName())
-        .isGlutenFree(bakery.getBreadType().getIsGlutenFree())
-        .isVegan(bakery.getBreadType().getIsVegan())
-        .isNutFree(bakery.getBreadType().getIsNutFree())
-        .isSugarFree(bakery.getBreadType().getIsSugarFree())
-        .build();
-  }
-
-  private BakeryListResponseDTO getBakeryResponseDTO(
-      Bakery bakery, BreadTypeResponseDTO breadType) {
-    return BakeryListResponseDTO.builder()
-        .bakeryId(bakery.getBakeryId())
-        .bakeryName(bakery.getBakeryName())
-        .bakeryPicture(bakery.getBakeryPicture())
-        .isHACCP(bakery.getIsHACCP())
-        .isVegan(bakery.getIsVegan())
-        .isNonGMO(bakery.getIsNonGMO())
-        .firstNearStation(bakery.getFirstNearStation())
-        .secondNearStation(bakery.getSecondNearStation())
-        .bookMarkCount(bakery.getBookMarkCount())
-        .reviewCount(bakery.getReviewCount())
-        .breadType(breadType)
-        .build();
-  }
-
   private BakeryListResponseDTOV2 getBakeryResponseDTOV2(
       Bakery bakery, boolean isBookMarked, BreadTypeResponseDTO breadType) {
     BaseBakeryResponseDTOV2 baseBakeryResponseDTOV2 =
@@ -277,28 +271,5 @@ public class BakeryService {
         .reviewCount(bakery.getReviewCount())
         .isBookMarked(isBookMarked)
         .build();
-  }
-
-  private List<Category> getCategoryList(boolean isHard, boolean isDessert, boolean isBrunch) {
-    List<Category> categoryList = new ArrayList<>();
-    if (isHard) {
-      categoryList.add(
-          categoryRepository
-              .findByCategoryName(CategoryType.HARD_BREAD.getName())
-              .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION)));
-    }
-    if (isDessert) {
-      categoryList.add(
-          categoryRepository
-              .findByCategoryName(CategoryType.DESSERT.getName())
-              .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION)));
-    }
-    if (isBrunch) {
-      categoryList.add(
-          categoryRepository
-              .findByCategoryName(CategoryType.BRUNCH.getName())
-              .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_CATEGORY_EXCEPTION)));
-    }
-    return categoryList;
   }
 }

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -36,7 +36,7 @@ public class BakeryService {
   private final int maxBestBakeryCount = 10;
 
   public List<BakeryListResponseDTO> getBakeryList(
-      Long memberId, String sort, boolean isHard, boolean isDessert, boolean isBrunch) {
+      String sort, boolean isHard, boolean isDessert, boolean isBrunch) {
     List<Category> categoryList = getCategoryList(isHard, isDessert, isBrunch);
     List<BakeryListResponseDTO> responseDtoList = new ArrayList<>();
     BreadTypeResponseDTO breadType;

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryCategoryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryCategoryRepository.java
@@ -1,5 +1,6 @@
 package com.org.gunbbang.repository;
 
+import com.org.gunbbang.entity.Bakery;
 import com.org.gunbbang.entity.BakeryCategory;
 import com.org.gunbbang.entity.Category;
 import java.util.List;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface BakeryCategoryRepository extends JpaRepository<BakeryCategory, Long> {
 
   List<BakeryCategory> findDistinctByCategoryIn(List<Category> categoryList, Sort sort);
+
+  long countBakeryCategoriesByBakery(Bakery bakery);
 }

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -64,13 +64,19 @@ public interface BakeryRepository
   List<Bakery> findBakeriesRandomly(PageRequest pageRequest);
 
   @Query(
-      value =
-          "SELECT DISTINCT b FROM Bakery b "
-              + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
-              + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId "
-              + "WHERE c IN :categoryList "
-              + "ORDER BY b.reviewCount DESC")
-  List<Bakery> findBakeriesByCategoryAndReview(List<Category> categoryList);
+      "SELECT DISTINCT b FROM Bakery b "
+          + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
+          + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId "
+          + "WHERE c IN :categoryList "
+          + "AND (b.breadType.isGlutenFree = :isGlutenFree OR b.breadType.isVegan = :isVegan "
+          + "OR b.breadType.isNutFree = :isNutFree OR b.breadType.isSugarFree = :isSugarFree) "
+          + "ORDER BY (SELECT COUNT(cat) FROM Category cat WHERE cat IN :categoryList) DESC")
+  List<Bakery> findFilteredBakeries(
+      @Param("categoryList") List<Category> categoryList,
+      @Param("isGlutenFree") boolean isGlutenFree,
+      @Param("isVegan") boolean isVegan,
+      @Param("isNutFree") boolean isNutFree,
+      @Param("isSugarFree") boolean isSugarFree);
 
   @Query(
       value =

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -65,8 +65,7 @@ public interface BakeryRepository
           + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId "
           + "WHERE c IN :categoryList "
           + "AND (b.breadType.isGlutenFree = :isGlutenFree OR b.breadType.isVegan = :isVegan "
-          + "OR b.breadType.isNutFree = :isNutFree OR b.breadType.isSugarFree = :isSugarFree) "
-          + "ORDER BY (SELECT COUNT(cat) FROM Category cat WHERE cat IN :categoryList) DESC")
+          + "OR b.breadType.isNutFree = :isNutFree OR b.breadType.isSugarFree = :isSugarFree)")
   List<Bakery> findFilteredBakeries(
       @Param("categoryList") List<Category> categoryList,
       @Param("isGlutenFree") boolean isGlutenFree,

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -6,7 +6,6 @@ import com.org.gunbbang.entity.BreadType;
 import com.org.gunbbang.entity.Category;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -60,9 +59,6 @@ public interface BakeryRepository
   List<Bakery> findRestBakeriesRandomly(
       @Param("alreadyFoundBakeryIds") List<Long> alreadyFoundBakeryIds, Pageable pageRequest);
 
-  @Query(value = "SELECT b FROM Bakery b " + "ORDER BY RAND() ")
-  List<Bakery> findBakeriesRandomly(PageRequest pageRequest);
-
   @Query(
       "SELECT DISTINCT b FROM Bakery b "
           + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
@@ -77,13 +73,4 @@ public interface BakeryRepository
       @Param("isVegan") boolean isVegan,
       @Param("isNutFree") boolean isNutFree,
       @Param("isSugarFree") boolean isSugarFree);
-
-  @Query(
-      value =
-          "SELECT DISTINCT b FROM Bakery b "
-              + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
-              + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId "
-              + "WHERE c IN :categoryList "
-              + "ORDER BY b.bakeryId DESC")
-  List<Bakery> findBakeriesByCategory(List<Category> categoryList);
 }

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -160,12 +160,18 @@ INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, ba
 
 
 -- bakery_category
-INSERT INTO bakery_category (bakery_id,category_id) values (3,1);
-INSERT INTO bakery_category (bakery_id,category_id) values (3,2);
-INSERT INTO bakery_category (bakery_id,category_id) values (3,3);
+INSERT INTO bakery_category (bakery_id,category_id) values (1,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (1,2);
+INSERT INTO bakery_category (bakery_id,category_id) values (1,3);
 INSERT INTO bakery_category (bakery_id,category_id) values (2,1);
 INSERT INTO bakery_category (bakery_id,category_id) values (2,2);
-INSERT INTO bakery_category (bakery_id,category_id) values (1,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (2,3);
+INSERT INTO bakery_category (bakery_id,category_id) values (3,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (3,2);
+INSERT INTO bakery_category (bakery_id,category_id) values (4,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (4,2);
+INSERT INTO bakery_category (bakery_id,category_id) values (5,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (5,2);
 
 
 -- menu
@@ -191,20 +197,20 @@ INSERT INTO book_mark (bakery_id, member_id) values (7, 5);
 
 -- review
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
-    VALUES (1, true, 'review_id: 1 | 제일최근 리뷰+좋아요+멤버빵유형 및 주목적 일치', 1, 2, '2023-07-13T18:00:29.68338Z', null);
+    VALUES (1, true, 'review_id: 1 | 제일최근 리뷰+좋아요+멤버빵유형 및 주목적 일치', 5, 2, '2023-07-13T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
-    VALUES (2, true, 'review_id: 2 | 두번째+좋아요+멤버빵유형 및 주목적 일치', 1, 2, '2023-07-12T18:00:29.68338Z', null);
+    VALUES (2, true, 'review_id: 2 | 두번째+좋아요+멤버빵유형 및 주목적 일치', 5, 2, '2023-07-12T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
-    VALUES (3, true, 'review_id: 3 | 세번째+좋아요+멤버빵유형 및 주목적 일치', 1, 2, '2023-07-11T18:00:29.68338Z', null);
+    VALUES (3, true, 'review_id: 3 | 세번째+좋아요+멤버빵유형 및 주목적 일치', 5, 2, '2023-07-11T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (4, true, 'review_id: 4 | 네번째+좋아요+멤버빵유형 및 주목적 일치', 4, 2, '2023-07-10T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
-    VALUES (5, true, 'review_id: 5 | 다섯+좋아요++멤버빵유형 및 주목적 일치', 5, 3, '2023-07-09T18:00:29.68338Z', null);
+    VALUES (5, true, 'review_id: 5 | 다섯+좋아요++멤버빵유형 및 주목적 일치', 4, 3, '2023-07-09T18:00:29.68338Z', null);
 
 -- 여기까지 best 리뷰에서 조회되어야 하는 데이터
 
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
-    VALUES (6, true, 'review_id: 6 | 좋아요+빵유형만 일치 이거 나오면 안됨', 1, 4, '2023-07-11T18:00:29.68338Z', null);
+    VALUES (6, true, 'review_id: 6 | 좋아요+빵유형만 일치 이거 나오면 안됨', 3, 4, '2023-07-11T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)
     VALUES (7, true, 'review_id: 7 | 좋아요+주목적만 일치 이거 나오면 안됨', 1, 5, '2023-07-13T18:00:29.68338Z', null);
 INSERT INTO review (review_id, is_like, review_text, bakery_id, member_id, created_at, updated_at)

--- a/storage/db-core/src/main/resources/init/h2-data.sql
+++ b/storage/db-core/src/main/resources/init/h2-data.sql
@@ -160,9 +160,11 @@ INSERT INTO bakery (bakery_id, bread_type_id, nutrient_type_id, address_rest, ba
 
 
 -- bakery_category
-INSERT INTO bakery_category (bakery_id,category_id) values (1,2);
+INSERT INTO bakery_category (bakery_id,category_id) values (3,1);
+INSERT INTO bakery_category (bakery_id,category_id) values (3,2);
+INSERT INTO bakery_category (bakery_id,category_id) values (3,3);
+INSERT INTO bakery_category (bakery_id,category_id) values (2,1);
 INSERT INTO bakery_category (bakery_id,category_id) values (2,2);
-INSERT INTO bakery_category (bakery_id,category_id) values (1,3);
 INSERT INTO bakery_category (bakery_id,category_id) values (1,1);
 
 


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- closed #159

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 건빵집 리스트에 사용자 맞춤 필터 적용하기 기능 추가
- QueryParameter 변수명 수정
- 우선 순위 적용
  - 유저가 선택한 카테고리가 2개 이상일 때 2개 -> 1개 일치하는 순으로 빵집 정렬
  - 유저가 맞춤 필터를 선택한 경우 -> 하나라도 일치하는 빵집이면 노출
  - 유저 필터 적용 + 카테고리 선택 시 리뷰 많은순으로 정렬되면 리뷰 많은 순이 가장 많은 가중치를 얻어 정렬됨

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="748" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/b65164ef-3e10-4f02-9a38-8246df80c45e">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- feat/#159라고 해야하는데 요즘 리팩토링 많이하다보니 습관적으로 fix라고 붙였네요 죄송합니다..ㅎ
