### PR TITLE
[FIX] 베스트 컨텐츠 조회 api 수정

### DIFF
--- a/api/src/main/java/com/org/gunbbang/jwt/filter/JwtExceptionFilter.java
+++ b/api/src/main/java/com/org/gunbbang/jwt/filter/JwtExceptionFilter.java
@@ -32,7 +32,6 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     String path = request.getRequestURI();
-    System.out.println("path: " + path);
     return WHITE_LIST.contains(path) || path.startsWith(H2_PREFIX);
   }
 

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -59,6 +59,9 @@ public interface BakeryRepository
   List<Bakery> findRestBakeriesRandomly(
       @Param("alreadyFoundBakeryIds") List<Long> alreadyFoundBakeryIds, Pageable pageRequest);
 
+  @Query(value = "SELECT b FROM Bakery b " + "ORDER BY RAND() ")
+  List<Bakery> findBakeriesRandomly(Pageable pageRequest);
+
   @Query(
       "SELECT DISTINCT b FROM Bakery b "
           + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/ReviewRepository.java
@@ -32,6 +32,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
       @Param("currentMemberBreadType") BreadType currentMemberBreadType,
       @Param("currentMemberMainPurpose") MainPurpose mainPurpose);
 
+  // 나와 같은 목적을 선택하고 같은 빵 유형을 선택한 다른 유저들이 작성한 리뷰 중 10개의 좋아요 리뷰 최신순
   @Query(
       value =
           "SELECT distinct new com.org.gunbbang.BestReviewDTO("
@@ -90,4 +91,30 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
               + "ORDER BY r.createdAt desc")
   List<BestReviewDTO> findRestBestReviewDTOListByBreadType(
       @Param("alreadyFoundReviews") List<Long> alreadyFoundReviews, PageRequest pageRequest);
+
+  @Query(
+      value =
+          "SELECT distinct new com.org.gunbbang.BestReviewDTO("
+              + "b.bakeryId, "
+              + "b.bakeryName, "
+              + "b.bakeryPicture, "
+              + "b.isHACCP, "
+              + "b.isVegan, "
+              + "b.isNonGMO, "
+              + "b.firstNearStation, "
+              + "b.secondNearStation, "
+              + "b.bookMarkCount, "
+              + "r.reviewId, "
+              + "b.reviewCount, "
+              + "r.reviewText, "
+              + "b.keywordDeliciousCount, "
+              + "b.keywordKindCount, "
+              + "b.keywordSpecialCount, "
+              + "b.keywordZeroWasteCount, "
+              + "r.createdAt) FROM Review r "
+              + "INNER JOIN Bakery b ON b.bakeryId = r.bakery.bakeryId "
+              + "INNER JOIN Member m ON r.member.memberId = m.memberId "
+              + "AND r.isLike = true ")
+  //                          + "ORDER BY RAND() ")
+  List<BestReviewDTO> findRandomBestReviewDTOList(PageRequest pageRequest);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
fix/#168 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회원이 필터칩 선택을 안했을 시 홈에서 베스트 리뷰와 랜덤 베스트 건빵집 반환

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
이슈가있읍니다,,,, 베스트 리뷰 조회 시 SELECT문에 DTO가 들어가서 그런지 `ORDER BY RAND()` 문에서 `Order by expression "RAND()" must be in the result list in this case;` 에러가 발생합니다,,, native query를 쓰는 수밖에 없을 것 같은데 현업에서는 쓰지 않는다고 들어서요 혹시 해결책은 없을지,,, 아신다면 공유 부탁드립니다,,,,,