### PR TITLE
[FIX] 건빵집 리스트 조회에서 정렬 조건 제대로 인식되지 않는 문제 해결해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -107,12 +107,11 @@ public class BakeryService {
 
     if ("review".equals(sortingOption)) {
       getSortedByCategoryBakeryList.sort(
-          Comparator.comparing(Bakery::getReviewCount, Collections.reverseOrder()));
-    } else if ("default".equals(sortingOption) && (!personalFilter)) {
-      getSortedByCategoryBakeryList.sort(
-          Comparator.comparing(Bakery::getBakeryId, Collections.reverseOrder()));
+          Comparator.comparingLong(Bakery::getReviewCount).reversed());
+      return getSortedByCategoryBakeryList;
     }
 
+    getSortedByCategoryBakeryList.sort(Comparator.comparingLong(Bakery::getBakeryId).reversed());
     return getSortedByCategoryBakeryList;
   }
 


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#174 -> dev
- closed #174

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- Comparator에서 long으로 인식하여 내림차순 정렬되도록 수정했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/22457831-69e7-4eac-9e8d-a6fc99a5fc3d)


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
