### PR TITLE
[FIX] 애플로그인 시 request body에서 email 필드를 가져오도록 수정

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/AppleAuthService.java
+++ b/api/src/main/java/com/org/gunbbang/service/AppleAuthService.java
@@ -1,9 +1,11 @@
 package com.org.gunbbang.service;
 
+import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.DTO.AppleAuthResponseDTO;
 import com.org.gunbbang.common.AuthType;
 import com.org.gunbbang.controller.DTO.request.MemberSignUpRequestDTO;
 import com.org.gunbbang.entity.Member;
+import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.jwt.service.AppleJwtService;
 import com.org.gunbbang.repository.BreadTypeRepository;
 import com.org.gunbbang.repository.MemberRepository;
@@ -29,16 +31,23 @@ public class AppleAuthService extends AuthService {
   @Override
   public SignedUpMemberVO saveMemberOrLogin(String platformToken, MemberSignUpRequestDTO request)
       throws Exception {
+    if (request.getEmail() == null || request.getEmail().isBlank()) {
+      log.warn("애플 회원가입 시 email 필드가 안옴");
+      throw new BadRequestException(
+          ErrorType.NO_REQUEST_PARAMETER_EXCEPTION,
+          ErrorType.NO_REQUEST_PARAMETER_EXCEPTION.getMessage()
+              + " email 필드 누락됨: "
+              + request.getEmail());
+    }
 
     AppleAuthResponseDTO response = appleJwtService.validateAuthorizationCode(platformToken);
-    String email = appleJwtService.getEmailFromIdentityToken(response.getId_token());
 
-    Member foundMember = getUser(request.getPlatformType(), email);
+    Member foundMember = getUser(request.getPlatformType(), request.getEmail());
     if (foundMember != null) {
       return SignedUpMemberVO.of(foundMember, response.getRefresh_token(), AuthType.LOGIN);
     }
 
-    Member savedMember = saveUser(request, email);
+    Member savedMember = saveUser(request, request.getEmail());
     return SignedUpMemberVO.of(savedMember, response.getRefresh_token(), AuthType.SIGN_UP);
   }
 }

--- a/api/src/main/java/com/org/gunbbang/service/NativeAuthService.java
+++ b/api/src/main/java/com/org/gunbbang/service/NativeAuthService.java
@@ -28,8 +28,22 @@ public class NativeAuthService extends AuthService {
   }
 
   @Override
-  public SignedUpMemberVO saveMemberOrLogin(String platformToken, MemberSignUpRequestDTO request)
-      throws Exception {
+  public SignedUpMemberVO saveMemberOrLogin(String platformToken, MemberSignUpRequestDTO request) {
+    if (isNullOrBlank(request.getPassword())
+        || isNullOrBlank(request.getNickname())
+        || isNullOrBlank(request.getEmail())) {
+      log.warn(
+          "자체로그인 시 필요한 요청 값이 오지 않음. pwd: {} nickname: {} email: {}",
+          request.getPassword(),
+          request.getNickname(),
+          request.getEmail());
+      throw new BadRequestException(
+          ErrorType.NO_REQUEST_PARAMETER_EXCEPTION,
+          ErrorType.NO_REQUEST_PARAMETER_EXCEPTION.getMessage()
+              + " email 필드 누락됨: "
+              + request.getEmail());
+    }
+
     if (memberRepository.findByEmail(request.getEmail()).isPresent()) {
       throw new BadRequestException(ErrorType.ALREADY_EXIST_EMAIL_EXCEPTION);
     }
@@ -40,5 +54,9 @@ public class NativeAuthService extends AuthService {
 
     Member savedMember = saveUser(request, request.getEmail());
     return SignedUpMemberVO.of(savedMember, null, AuthType.SIGN_UP);
+  }
+
+  private boolean isNullOrBlank(String input) {
+    return input == null || input.isBlank();
   }
 }

--- a/common/exception/src/main/java/com/org/gunbbang/BadRequestException.java
+++ b/common/exception/src/main/java/com/org/gunbbang/BadRequestException.java
@@ -6,4 +6,8 @@ public class BadRequestException extends HandleException {
   public BadRequestException(ErrorType errorType) {
     super(errorType);
   }
+
+  public BadRequestException(ErrorType errorType, String message) {
+    super(errorType, message);
+  }
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
fix/#177-1 -> dev

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 애플로그인 시 request body에서 email 필드를 가져오도록 수정
- 자체로그인 null 체크 추가

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
