### PR TITLE
[FIX] 별로에요인 리뷰에서 추천키워드가 함께 입력되면 에러를 반환해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
@@ -1,12 +1,10 @@
 package com.org.gunbbang.controller;
 
 import com.org.gunbbang.AOP.annotation.BakeryIdApiLog;
-import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.common.DTO.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.ReviewRequestDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewCreateResponseDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewDetailResponseDTO;
-import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.errorType.SuccessType;
 import com.org.gunbbang.service.ReviewService;
 import javax.validation.Valid;
@@ -26,10 +24,6 @@ public class ReviewsController {
   public ApiResponse<ReviewCreateResponseDTO> createReview(
       @PathVariable("bakeryId") final Long bakeryId,
       @RequestBody @Valid final ReviewRequestDTO request) {
-    if (request.getIsLike().equals(Boolean.FALSE) && (!request.getKeywordList().isEmpty())) {
-      throw new BadRequestException(ErrorType.REQUEST_ISNOTLIKE_KEYWORDLIST_VALIDATION_EXCEPTION);
-    }
-
     Long reviewId = reviewService.createReview(bakeryId, request);
     return ApiResponse.success(
         SuccessType.CREATE_REVIEW_SUCCESS,

--- a/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
+++ b/api/src/main/java/com/org/gunbbang/controller/ReviewsController.java
@@ -1,10 +1,12 @@
 package com.org.gunbbang.controller;
 
 import com.org.gunbbang.AOP.annotation.BakeryIdApiLog;
+import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.common.DTO.ApiResponse;
 import com.org.gunbbang.controller.DTO.request.ReviewRequestDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewCreateResponseDTO;
 import com.org.gunbbang.controller.DTO.response.ReviewDetailResponseDTO;
+import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.errorType.SuccessType;
 import com.org.gunbbang.service.ReviewService;
 import javax.validation.Valid;
@@ -24,6 +26,10 @@ public class ReviewsController {
   public ApiResponse<ReviewCreateResponseDTO> createReview(
       @PathVariable("bakeryId") final Long bakeryId,
       @RequestBody @Valid final ReviewRequestDTO request) {
+    if (request.getIsLike().equals(Boolean.FALSE) && (!request.getKeywordList().isEmpty())) {
+      throw new BadRequestException(ErrorType.REQUEST_ISNOTLIKE_KEYWORDLIST_VALIDATION_EXCEPTION);
+    }
+
     Long reviewId = reviewService.createReview(bakeryId, request);
     return ApiResponse.success(
         SuccessType.CREATE_REVIEW_SUCCESS,

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -38,6 +38,12 @@ public class ReviewService {
 
   public Long createReview(Long bakeryId, ReviewRequestDTO reviewRequestDto) {
     Long currentMemberId = SecurityUtil.getLoginMemberId();
+
+    if (reviewRequestDto.getIsLike().equals(Boolean.FALSE)
+        && !reviewRequestDto.getKeywordList().isEmpty()) {
+      throw new BadRequestException(ErrorType.REQUEST_ISNOTLIKE_KEYWORDLIST_VALIDATION_EXCEPTION);
+    }
+
     Member member =
         memberRepository
             .findById(currentMemberId)

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
@@ -12,6 +12,8 @@ public enum ErrorType {
   REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
   REQUEST_KEYWORDLIST_VALIDATION_EXCEPTION(
       HttpStatus.BAD_REQUEST, "좋아요 선택시 추천 키워드를 하나 이상 선택해야 합니다"),
+  REQUEST_ISNOTLIKE_KEYWORDLIST_VALIDATION_EXCEPTION(
+      HttpStatus.BAD_REQUEST, "별로에요 리뷰 시 키워드를 선택할 수 없습니다"),
   INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 비밀번호입니다"),
   TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "만료된 토큰입니다"),
   ALREADY_BOOKMARKED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 북마크된 빵집입니다"),


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#193 -> dev
- closed #193

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 별로에요 리뷰에서 추천 키워드가 입력되면 에러를 반환하도록 로직을 수정했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="747" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/abb615ef-f35d-4fa1-9f15-3b6af83c95e4">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 입력값 검증을 contoller 단에서 하는게 좋을지, 아니면 service 단에서 하는게 좋을지 궁금합니다!
