### PR TITLE
[FIX] 키워드 퍼센트 반환 시 특별해요 퍼센트 계산 인자를 수정해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -128,7 +128,7 @@ public class ReviewService {
     RecommendKeywordPercentage recommendKeywordPercentage =
         RecommendKeywordPercentage.builder()
             .deliciousPercent(calculatorPercentage(reviewCount, bakery.getKeywordDeliciousCount()))
-            .specialPercent(calculatorPercentage(reviewCount, bakery.getKeywordDeliciousCount()))
+            .specialPercent(calculatorPercentage(reviewCount, bakery.getKeywordSpecialCount()))
             .kindPercent(calculatorPercentage(reviewCount, bakery.getKeywordKindCount()))
             .zeroWastePercent(calculatorPercentage(reviewCount, bakery.getKeywordZeroWasteCount()))
             .build();


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#196 -> dev
- closed #196

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 맛있어요와 특별해요 키워드에 대한 퍼센트가 같게 전달되는 문제를 해결했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="782" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/66236569-6cd3-43f6-b170-1ac81258e2bb">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
