### PR TITLE
[FIX] 빵유형을 선택하지 않은 유저가 pesonalFilter true로 요청할 시에 대한 에러처리를 추가해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -1,5 +1,6 @@
 package com.org.gunbbang.service;
 
+import com.org.gunbbang.BadRequestException;
 import com.org.gunbbang.CategoryType;
 import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.NotFoundException;
@@ -44,6 +45,14 @@ public class BakeryService {
       boolean isDessert,
       boolean isBrunch) {
     Long memberBreadTypeId = SecurityUtil.getLoginMemberBreadTypeId();
+    if (Objects.equals(
+            memberBreadTypeId,
+            breadTypeRepository
+                .findByBreadTypeName("빵유형 필터 선택 안함")
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION))
+                .getBreadTypeId())
+        && personalFilter) throw new BadRequestException(ErrorType.PERSONAL_FILTER_EXCEPTION);
+
     List<Category> categoryList = getCategoryList(isHard, isDessert, isBrunch);
     List<Bakery> bakeryList =
         getFilteredAndSortedBakeryList(

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -45,10 +45,10 @@ public class BakeryService {
       boolean isDessert,
       boolean isBrunch) {
     Long memberBreadTypeId = SecurityUtil.getLoginMemberBreadTypeId();
-    if (Objects.equals(
-            memberBreadTypeId,
+    if (memberBreadTypeId.equals(
             breadTypeRepository
-                .findByBreadTypeName("빵유형 필터 선택 안함")
+                .findBreadTypeByIsGlutenFreeAndIsVeganAndIsNutFreeAndIsSugarFree(
+                    false, false, false, false)
                 .orElseThrow(() -> new NotFoundException(ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION))
                 .getBreadTypeId())
         && personalFilter) throw new BadRequestException(ErrorType.PERSONAL_FILTER_EXCEPTION);

--- a/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
+++ b/common/exception/src/main/java/com/org/gunbbang/errorType/ErrorType.java
@@ -23,6 +23,7 @@ public enum ErrorType {
   PARAMETER_TYPE_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값의 타입이 올바르지 않습니다"),
   REQUEST_BIND_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값 바인딩에 실패했습니다"),
   LOGIN_FAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인에 실패하였습니다. 아이디나 비밀번호 확인해주세요"),
+  PERSONAL_FILTER_EXCEPTION(HttpStatus.BAD_REQUEST, "필터 선택을 하지 않은 경우 맞춤 필터링을 적용할 수 없습니다"),
 
   /** 401 */
   ABUSED_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰 재발급 실패"),

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BreadTypeRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BreadTypeRepository.java
@@ -9,6 +9,4 @@ public interface BreadTypeRepository extends JpaRepository<BreadType, Long> {
   // TODO: getDefaultBreadType으로 수정
   Optional<BreadType> findBreadTypeByIsGlutenFreeAndIsVeganAndIsNutFreeAndIsSugarFree(
       boolean isGlutenFree, boolean isVegan, boolean isNutFree, boolean isSugarFree);
-
-  Optional<BreadType> findByBreadTypeName(String breadTypeName);
 }

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BreadTypeRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BreadTypeRepository.java
@@ -9,4 +9,6 @@ public interface BreadTypeRepository extends JpaRepository<BreadType, Long> {
   // TODO: getDefaultBreadType으로 수정
   Optional<BreadType> findBreadTypeByIsGlutenFreeAndIsVeganAndIsNutFreeAndIsSugarFree(
       boolean isGlutenFree, boolean isVegan, boolean isNutFree, boolean isSugarFree);
+
+  Optional<BreadType> findByBreadTypeName(String breadTypeName);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#198 -> dev
- closed #198

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 건빵집 리스트 조회 시, 필터 선택을 하지 않은 유저가 personalFilter를 true로 요청 보낼 시에 대한 에러 처리를 추가했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="752" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/3b3a946b-ffdc-49a7-a8d4-379315246ab8">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
