### PR TITLE
[FIX] 좋아요 리뷰 작성 시 추천키워드 한개 이상 선택하지 않으면 에러를 반환해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -72,6 +72,11 @@ public class ReviewService {
 
   private void createReviewRecommendKeyword(
       List<RecommendKeywordNameRequestDTO> keywordNameRequestDtoList, Long reviewId) {
+
+    if (keywordNameRequestDtoList.isEmpty()) {
+      throw new BadRequestException(ErrorType.REQUEST_KEYWORDLIST_VALIDATION_EXCEPTION);
+    }
+
     Review review =
         reviewRepository
             .findById(reviewId)

--- a/api/src/main/java/com/org/gunbbang/service/ReviewService.java
+++ b/api/src/main/java/com/org/gunbbang/service/ReviewService.java
@@ -39,8 +39,7 @@ public class ReviewService {
   public Long createReview(Long bakeryId, ReviewRequestDTO reviewRequestDto) {
     Long currentMemberId = SecurityUtil.getLoginMemberId();
 
-    if (reviewRequestDto.getIsLike().equals(Boolean.FALSE)
-        && !reviewRequestDto.getKeywordList().isEmpty()) {
+    if (!reviewRequestDto.getIsLike() && !reviewRequestDto.getKeywordList().isEmpty()) {
       throw new BadRequestException(ErrorType.REQUEST_ISNOTLIKE_KEYWORDLIST_VALIDATION_EXCEPTION);
     }
 


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#200 -> dev
- closed #200

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 좋아요 리뷰 작성 시 추천 키워드를 한개 이상 선택하지 않으면 에러를 반환합니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/4dc55b3c-884a-411a-a413-e78147d3a132)


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
