### PR TITLE
[FEAT] 카카오톡 소셜로그인 선택적 동의 정보 받아오는 기능 구현해라

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/KakaoAuthService.java
+++ b/api/src/main/java/com/org/gunbbang/service/KakaoAuthService.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.org.gunbbang.InvalidKakaoTokenException;
 import com.org.gunbbang.common.AuthType;
 import com.org.gunbbang.controller.DTO.request.MemberSignUpRequestDTO;
+import com.org.gunbbang.entity.KakaoMember;
 import com.org.gunbbang.entity.Member;
 import com.org.gunbbang.errorType.ErrorType;
 import com.org.gunbbang.repository.BreadTypeRepository;
+import com.org.gunbbang.repository.KakaoMemberRepository;
 import com.org.gunbbang.repository.MemberRepository;
 import com.org.gunbbang.repository.NutrientTypeRepository;
 import com.org.gunbbang.service.VO.KakaoUserVO;
@@ -25,11 +27,15 @@ public class KakaoAuthService extends AuthService {
   @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
   private String kakaoUserInfoUri;
 
+  private final KakaoMemberRepository kakaoMemberRepository;
+
   public KakaoAuthService(
       MemberRepository memberRepository,
       BreadTypeRepository breadTypeRepository,
-      NutrientTypeRepository nutrientTypeRepository) {
+      NutrientTypeRepository nutrientTypeRepository,
+      KakaoMemberRepository kakaoMemberRepository) {
     super(memberRepository, breadTypeRepository, nutrientTypeRepository);
+    this.kakaoMemberRepository = kakaoMemberRepository;
   }
 
   @Override
@@ -62,6 +68,12 @@ public class KakaoAuthService extends AuthService {
       }
 
       Member savedMember = saveUser(request, userInfoVO.getKakaoAccount().getEmail());
+      System.out.println(userInfoVO);
+
+      if (!userInfoVO.getKakaoAccount().getAge_range_needs_agreement()
+          || !userInfoVO.getKakaoAccount().getGender_needs_agreement()) {
+        saveKakaoMemberInfo(userInfoVO, savedMember);
+      }
       return SignedUpMemberVO.of(savedMember, null, AuthType.SIGN_UP);
 
     } catch (Exception e) {
@@ -69,5 +81,15 @@ public class KakaoAuthService extends AuthService {
           ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION,
           ErrorType.INVALID_KAKAO_TOKEN_EXCEPTION.getMessage());
     }
+  }
+
+  private void saveKakaoMemberInfo(KakaoUserVO kakaoUserVo, Member member) {
+    KakaoMember newKakaoMember =
+        KakaoMember.builder()
+            .member(member)
+            .gender(kakaoUserVo.getKakaoAccount().getGender())
+            .age_range(kakaoUserVo.getKakaoAccount().getAge_range())
+            .build();
+    kakaoMemberRepository.save(newKakaoMember);
   }
 }

--- a/api/src/main/java/com/org/gunbbang/service/KakaoAuthService.java
+++ b/api/src/main/java/com/org/gunbbang/service/KakaoAuthService.java
@@ -68,7 +68,6 @@ public class KakaoAuthService extends AuthService {
       }
 
       Member savedMember = saveUser(request, userInfoVO.getKakaoAccount().getEmail());
-      System.out.println(userInfoVO);
 
       if (!userInfoVO.getKakaoAccount().getAge_range_needs_agreement()
           || !userInfoVO.getKakaoAccount().getGender_needs_agreement()) {

--- a/api/src/main/java/com/org/gunbbang/service/VO/KakaoUserVO.java
+++ b/api/src/main/java/com/org/gunbbang/service/VO/KakaoUserVO.java
@@ -2,6 +2,7 @@ package com.org.gunbbang.service.VO;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
@@ -15,6 +16,22 @@ public class KakaoUserVO {
   @Getter
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class KakaoAccount {
-    private String email;
+    @NotNull private String email;
+    private Boolean age_range_needs_agreement;
+    private String age_range;
+    private Boolean gender_needs_agreement;
+    private String gender;
+  }
+
+  @Override
+  public String toString() {
+    return "KakaoUserVO{"
+        + "id="
+        + id
+        + "age_range_need_agreement="
+        + kakaoAccount.getAge_range_needs_agreement()
+        + "gender_need_agreement="
+        + kakaoAccount.getGender_needs_agreement()
+        + '}';
   }
 }

--- a/storage/db-core/src/main/java/com/org/gunbbang/entity/KakaoMember.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/entity/KakaoMember.java
@@ -1,0 +1,22 @@
+package com.org.gunbbang.entity;
+
+import javax.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class KakaoMember {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  private String age_range;
+  private String gender;
+}

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/KakaoMemberRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/KakaoMemberRepository.java
@@ -1,0 +1,6 @@
+package com.org.gunbbang.repository;
+
+import com.org.gunbbang.entity.KakaoMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KakaoMemberRepository extends JpaRepository<KakaoMember, Long> {}


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#205 -> dev
- closed #205

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 카카오톡 소셜로그인 시 나이대와 성별을 받아오는 로직을 구현했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/6c85a877-d99a-4a1a-a66e-2a1b1690f9c9)
<img width="915" alt="image" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/0ee21020-000b-4811-8b14-c2d53bc653dc">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
