### PR TITLE
[FIX] 건빵집 리스트 조회에서 카테고리는 일치하지만 유저 필터칩과 일치하지 않는 빵집 조회되는 케이스 수정해라

### DIFF
--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -66,9 +66,13 @@ public interface BakeryRepository
       "SELECT DISTINCT b FROM Bakery b "
           + "INNER JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
           + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId "
-          + "WHERE c IN :categoryList "
-          + "AND (b.breadType.isGlutenFree = :isGlutenFree OR b.breadType.isVegan = :isVegan "
-          + "OR b.breadType.isNutFree = :isNutFree OR b.breadType.isSugarFree = :isSugarFree)")
+          + "WHERE (c IN :categoryList) "
+          + "AND ( "
+          + "(:isGlutenFree = true AND b.breadType.isGlutenFree = true) OR "
+          + "(:isVegan = true AND b.breadType.isVegan = true) OR "
+          + "(:isNutFree = true AND b.breadType.isNutFree = true) OR "
+          + "(:isSugarFree = true AND b.breadType.isSugarFree = true)"
+          + ")")
   List<Bakery> findFilteredBakeries(
       @Param("categoryList") List<Category> categoryList,
       @Param("isGlutenFree") boolean isGlutenFree,


### PR DESCRIPTION
## 🍞 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- fix/#244 -> dev
- closed #244

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 빵집 카테고리는 일치하지만 유저 필터칩과 일치하지 않는 케이스에 대해 수정 보완했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/49457fc2-74d9-425b-a0fc-1e0e0481453d)


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
