### PR TITLE
[FEAT] 건빵집 리스트 조회 테이블 변경에 따른 수정

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -110,15 +110,10 @@ public class BakeryService {
                 .map(MemberBreadType::getBreadType)
                 .collect(Collectors.toList())
             : breadTypeRepository.findAll();
-    MemberNutrientType memberNutrintType =
-        memberNutrientTypeRepository
-            .findByMemberId(memberId)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        ErrorType.NOT_FOUND_NUTRIENT_EXCEPTION,
-                        ErrorType.NOT_FOUND_NUTRIENT_EXCEPTION.getMessage()));
-    NutrientType bakeryNutrientType = memberNutrintType.getNutrientType();
+    List<MemberNutrientType> memberNutrintTypes =
+        memberNutrientTypeRepository.findByMemberId(memberId);
+    MemberNutrientType memberNutrientType = memberNutrintTypes.get(0);
+    NutrientType bakeryNutrientType = memberNutrientType.getNutrientType();
     List<Bakery> filteredBakeryList =
         bakeryRepository.findFilteredBakeries(categoryList, breadType, bakeryNutrientType);
 

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -1,5 +1,6 @@
 package com.org.gunbbang.service;
 
+import com.org.gunbbang.CategoryType;
 import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.NotFoundException;
 import com.org.gunbbang.auth.security.util.SecurityUtil;
@@ -35,6 +36,7 @@ public class BakeryService {
   private final MemberBreadTypeRepository memberBreadTypeRepository;
   private final MemberNutrientTypeRepository memberNutrientTypeRepository;
   private final BakeryBreadTypeRepository bakeryBreadTypeRepository;
+  private final BakeryNutrientTypeRepository bakeryNutrientTypeRepository;
 
   private final String BLANK_SPACE = " ";
   private final int maxBestBakeryCount = 10;
@@ -45,126 +47,106 @@ public class BakeryService {
       boolean isHard,
       boolean isDessert,
       boolean isBrunch) {
-    return null;
+    Long memberId = SecurityUtil.getLoginMemberId();
+    List<MemberBreadType> memberBreadType = memberBreadTypeRepository.findAllByMemberId(memberId);
+
+    List<Category> categoryList = getCategoryList(isHard, isDessert, isBrunch);
+    List<Bakery> bakeryList =
+        getFilteredAndSortedBakeryList(
+            personalFilter, memberBreadType, categoryList, sortingOption, memberId);
+    return getBakeryListResponseDTOList(bakeryList);
   }
 
-  //  public List<BakeryListResponseDTO> getBakeryList(
-  //      String sortingOption,
-  //      boolean personalFilter,
-  //      boolean isHard,
-  //      boolean isDessert,
-  //      boolean isBrunch) {
-  //    Long memberBreadTypeId = SecurityUtil.getLoginMemberBreadTypeId();
-  //    if (memberBreadTypeId.equals(
-  //            breadTypeRepository
-  //                .findBreadTypeByIsGlutenFreeAndIsVeganAndIsNutFreeAndIsSugarFree(
-  //                    false, false, false, false)
-  //                .orElseThrow(() -> new
-  // NotFoundException(ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION))
-  //                .getBreadTypeId())
-  //        && personalFilter) throw new BadRequestException(ErrorType.PERSONAL_FILTER_EXCEPTION);
-  //
-  //    List<Category> categoryList = getCategoryList(isHard, isDessert, isBrunch);
-  //    List<Bakery> bakeryList =
-  //        getFilteredAndSortedBakeryList(
-  //            personalFilter, memberBreadTypeId, categoryList, sortingOption);
-  //    return getBakeryListResponseDTOList(bakeryList);
-  //  }
-  //
-  //  private List<Category> getCategoryList(boolean isHard, boolean isDessert, boolean isBrunch) {
-  //    List<Category> categoryList = new ArrayList<>();
-  //
-  //    Map<CategoryType, Boolean> categoryMap = new HashMap<>();
-  //    categoryMap.put(CategoryType.HARD_BREAD, isHard);
-  //    categoryMap.put(CategoryType.DESSERT, isDessert);
-  //    categoryMap.put(CategoryType.BRUNCH, isBrunch);
-  //
-  //    for (Map.Entry<CategoryType, Boolean> entry : categoryMap.entrySet()) {
-  //      if (entry.getValue()) { // true인 값만 해당되어 category에 추가된다
-  //        Category category =
-  //            categoryRepository
-  //                .findByCategoryName(entry.getKey().getName())
-  //                .orElseThrow(
-  //                    () ->
-  //                        new NotFoundException(
-  //                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION,
-  //                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()
-  //                                + entry.getKey().getName()));
-  //        categoryList.add(category);
-  //      }
-  //    }
-  //
-  //    if (categoryList.isEmpty()) { // 카테고리가 빈 경우
-  //      for (CategoryType categoryType : CategoryType.values()) {
-  //        Category category =
-  //            categoryRepository
-  //                .findByCategoryName(categoryType.getName())
-  //                .orElseThrow(
-  //                    () ->
-  //                        new NotFoundException(
-  //                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION,
-  //                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()
-  //                                + categoryType.getName()));
-  //        categoryList.add(category);
-  //      }
-  //    }
-  //
-  //    return categoryList;
-  //  }
-  //
-  //  private List<Bakery> getFilteredAndSortedBakeryList(
-  //      boolean personalFilter, Long breadTypeId, List<Category> categoryList, String
-  // sortingOption) {
-  //    BreadType breadType =
-  //        personalFilter
-  //            ? breadTypeRepository
-  //                .findById(breadTypeId)
-  //                .orElseThrow(
-  //                    () ->
-  //                        new NotFoundException(
-  //                            ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION,
-  //                            ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION.getMessage() +
-  // breadTypeId))
-  //            : breadTypeRepository
-  //                .findBreadTypeByIsGlutenFreeAndIsVeganAndIsNutFreeAndIsSugarFree(
-  //                    true, true, true, true)
-  //                .orElseThrow(() -> new
-  // NotFoundException(ErrorType.NOT_FOUND_BREAD_TYPE_EXCEPTION));
-  //
-  //    List<Bakery> filteredBakeryList =
-  //        bakeryRepository.findFilteredBakeries(
-  //            categoryList,
-  //            breadType.getIsGlutenFree(),
-  //            breadType.getIsVegan(),
-  //            breadType.getIsNutFree(),
-  //            breadType.getIsSugarFree());
-  //
-  //    List<Bakery> getSortedByCategoryBakeryList =
-  // getSortedByCategoryBakeryList(filteredBakeryList);
-  //
-  //    if ("review".equals(sortingOption)) {
-  //      getSortedByCategoryBakeryList.sort(
-  //          Comparator.comparingLong(Bakery::getReviewCount).reversed());
-  //      return getSortedByCategoryBakeryList;
-  //    }
-  //
-  //    return getSortedByCategoryBakeryList;
-  //  }
-  //
-  //  private List<Bakery> getSortedByCategoryBakeryList(List<Bakery> bakeryList) {
-  //    Map<Bakery, Long> bakeryCategoryCounts = new HashMap<>();
-  //
-  //    for (Bakery bakery : bakeryList) {
-  //      long count = bakeryCategoryRepository.countBakeryCategoriesByBakery(bakery);
-  //      log.info("########## bakeryName: {} count: {} ##########", bakery.getBakeryName(), count);
-  //      bakeryCategoryCounts.put(bakery, count);
-  //    }
-  //
-  //    return bakeryCategoryCounts.entrySet().stream()
-  //        .sorted(Map.Entry.<Bakery, Long>comparingByValue().reversed())
-  //        .map(Map.Entry::getKey)
-  //        .collect(Collectors.toList());
-  //  }
+  private List<Category> getCategoryList(boolean isHard, boolean isDessert, boolean isBrunch) {
+    List<Category> categoryList = new ArrayList<>();
+
+    Map<CategoryType, Boolean> categoryMap = new HashMap<>();
+    categoryMap.put(CategoryType.HARD_BREAD, isHard);
+    categoryMap.put(CategoryType.DESSERT, isDessert);
+    categoryMap.put(CategoryType.BRUNCH, isBrunch);
+
+    for (Map.Entry<CategoryType, Boolean> entry : categoryMap.entrySet()) {
+      if (entry.getValue()) { // true인 값만 해당되어 category에 추가된다
+        Category category =
+            categoryRepository
+                .findByCategoryName(entry.getKey().getName())
+                .orElseThrow(
+                    () ->
+                        new NotFoundException(
+                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION,
+                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()
+                                + entry.getKey().getName()));
+        categoryList.add(category);
+      }
+    }
+
+    if (categoryList.isEmpty()) { // 카테고리가 빈 경우
+      for (CategoryType categoryType : CategoryType.values()) {
+        Category category =
+            categoryRepository
+                .findByCategoryName(categoryType.getName())
+                .orElseThrow(
+                    () ->
+                        new NotFoundException(
+                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION,
+                            ErrorType.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()
+                                + categoryType.getName()));
+        categoryList.add(category);
+      }
+    }
+
+    return categoryList;
+  }
+
+  private List<Bakery> getFilteredAndSortedBakeryList(
+      boolean personalFilter,
+      List<MemberBreadType> memberBreadType,
+      List<Category> categoryList,
+      String sortingOption,
+      Long memberId) {
+    List<BreadType> breadType =
+        personalFilter
+            ? memberBreadType.stream()
+                .map(MemberBreadType::getBreadType)
+                .collect(Collectors.toList())
+            : breadTypeRepository.findAll();
+    MemberNutrientType memberNutrintType =
+        memberNutrientTypeRepository
+            .findByMemberId(memberId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        ErrorType.NOT_FOUND_NUTRIENT_EXCEPTION,
+                        ErrorType.NOT_FOUND_NUTRIENT_EXCEPTION.getMessage()));
+    NutrientType bakeryNutrientType = memberNutrintType.getNutrientType();
+    List<Bakery> filteredBakeryList =
+        bakeryRepository.findFilteredBakeries(categoryList, breadType, bakeryNutrientType);
+
+    List<Bakery> getSortedByCategoryBakeryList = getSortedByCategoryBakeryList(filteredBakeryList);
+
+    if ("review".equals(sortingOption)) {
+      getSortedByCategoryBakeryList.sort(
+          Comparator.comparingLong(Bakery::getReviewCount).reversed());
+      return getSortedByCategoryBakeryList;
+    }
+
+    return getSortedByCategoryBakeryList;
+  }
+
+  private List<Bakery> getSortedByCategoryBakeryList(List<Bakery> bakeryList) {
+    Map<Bakery, Long> bakeryCategoryCounts = new HashMap<>();
+
+    for (Bakery bakery : bakeryList) {
+      long count = bakeryCategoryRepository.countBakeryCategoriesByBakery(bakery);
+      log.info("########## bakeryName: {} count: {} ##########", bakery.getBakeryName(), count);
+      bakeryCategoryCounts.put(bakery, count);
+    }
+
+    return bakeryCategoryCounts.entrySet().stream()
+        .sorted(Map.Entry.<Bakery, Long>comparingByValue().reversed())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+  }
 
   public BakeryDetailResponseDTO getBakeryDetail(Long bakeryId) {
     Long memberId = SecurityUtil.getUserId().orElse(null);

--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -3,6 +3,7 @@ package com.org.gunbbang.service;
 import com.org.gunbbang.CategoryType;
 import com.org.gunbbang.MainPurpose;
 import com.org.gunbbang.NotFoundException;
+import com.org.gunbbang.NutrientTypeTag;
 import com.org.gunbbang.auth.security.util.SecurityUtil;
 import com.org.gunbbang.controller.DTO.response.*;
 import com.org.gunbbang.entity.*;
@@ -36,7 +37,7 @@ public class BakeryService {
   private final MemberBreadTypeRepository memberBreadTypeRepository;
   private final MemberNutrientTypeRepository memberNutrientTypeRepository;
   private final BakeryBreadTypeRepository bakeryBreadTypeRepository;
-  private final BakeryNutrientTypeRepository bakeryNutrientTypeRepository;
+  private final NutrientTypeRepository nutrientTypeRepository;
 
   private final String BLANK_SPACE = " ";
   private final int maxBestBakeryCount = 10;
@@ -113,7 +114,10 @@ public class BakeryService {
     List<MemberNutrientType> memberNutrintTypes =
         memberNutrientTypeRepository.findByMemberId(memberId);
     MemberNutrientType memberNutrientType = memberNutrintTypes.get(0);
-    NutrientType bakeryNutrientType = memberNutrientType.getNutrientType();
+    NutrientType bakeryNutrientType =
+        personalFilter
+            ? memberNutrientType.getNutrientType()
+            : nutrientTypeRepository.findByNutrientTypeTag(NutrientTypeTag.NOT_OPEN).orElse(null);
     List<Bakery> filteredBakeryList =
         bakeryRepository.findFilteredBakeries(categoryList, breadType, bakeryNutrientType);
 

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -64,13 +64,16 @@ public interface BakeryRepository
 
   @Query(
       value =
-          "SELECT b FROM Bakery b "
-              + "JOIN BakeryBreadType bbt ON b.bakeryId = bbt.bakery.bakeryId "
-              + "JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
-              + "JOIN BakeryNutrientType bnt ON b.bakeryId = bnt.bakery.bakeryId "
-              + "WHERE bbt.breadType IN :breadTypeList "
-              + "AND bc.category IN :categoryList "
-              + "AND bnt.nutrientType = :bakeryNutrientType")
+          "SELECT DISTINCT b FROM Bakery b "
+              + "WHERE b.bakeryId IN ("
+              + "SELECT bbt.bakery.bakeryId FROM BakeryBreadType bbt WHERE bbt.breadType IN :breadTypeList"
+              + ") "
+              + "AND b.bakeryId IN ("
+              + "SELECT bc.bakery.bakeryId FROM BakeryCategory bc WHERE bc.category IN :categoryList"
+              + ") "
+              + "AND b.bakeryId IN ("
+              + "SELECT bnt.bakery.bakeryId FROM BakeryNutrientType bnt WHERE bnt.nutrientType = :bakeryNutrientType"
+              + ")")
   List<Bakery> findFilteredBakeries(
       @Param("categoryList") List<Category> categoryList,
       @Param("breadTypeList") List<BreadType> breadTypeList,

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -64,7 +64,13 @@ public interface BakeryRepository
 
   @Query(
       value =
-          "SELECT b FROM Bakery b join BakeryBreadType bbt join BakeryCategory bc join BakeryNutrientType bnt where bbt.breadType in :breadTypeList and bc.category in :categoryList and  bnt.nutrientType = :bakeryNutrientType")
+          "SELECT b FROM Bakery b "
+              + "JOIN BakeryBreadType bbt ON b.bakeryId = bbt.bakery.bakeryId "
+              + "JOIN BakeryCategory bc ON b.bakeryId = bc.bakery.bakeryId "
+              + "JOIN BakeryNutrientType bnt ON b.bakeryId = bnt.bakery.bakeryId "
+              + "WHERE bbt.breadType IN :breadTypeList "
+              + "AND bc.category IN :categoryList "
+              + "AND bnt.nutrientType = :bakeryNutrientType")
   List<Bakery> findFilteredBakeries(
       @Param("categoryList") List<Category> categoryList,
       @Param("breadTypeList") List<BreadType> breadTypeList,

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/BakeryRepository.java
@@ -1,8 +1,7 @@
 package com.org.gunbbang.repository;
 
 import com.org.gunbbang.MainPurpose;
-import com.org.gunbbang.entity.Bakery;
-import com.org.gunbbang.entity.BreadType;
+import com.org.gunbbang.entity.*;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -63,14 +62,11 @@ public interface BakeryRepository
   @Query(value = "SELECT b FROM Bakery b " + "ORDER BY RAND() ")
   List<Bakery> findBakeriesRandomly(Pageable pageRequest);
 
-  /**
-   * @Query( "SELECT DISTINCT b FROM Bakery b " + "INNER JOIN BakeryCategory bc ON b.bakeryId =
-   * bc.bakery.bakeryId " + "INNER JOIN Category c ON bc.category.categoryId = c.categoryId " +
-   * "WHERE (c IN :categoryList) " + "AND ( " + "(:isGlutenFree = true AND b.breadType.isGlutenFree
-   * = true) OR " + "(:isVegan = true AND b.breadType.isVegan = true) OR " + "(:isNutFree = true AND
-   * b.breadType.isNutFree = true) OR " + "(:isSugarFree = true AND b.breadType.isSugarFree = true)"
-   * + ")") List<Bakery> findFilteredBakeries( @Param("categoryList") List<Category>
-   * categoryList, @Param("isGlutenFree") boolean isGlutenFree, @Param("isVegan") boolean
-   * isVegan, @Param("isNutFree") boolean isNutFree, @Param("isSugarFree") boolean isSugarFree);
-   */
+  @Query(
+      value =
+          "SELECT b FROM Bakery b join BakeryBreadType bbt join BakeryCategory bc join BakeryNutrientType bnt where bbt.breadType in :breadTypeList and bc.category in :categoryList and  bnt.nutrientType = :bakeryNutrientType")
+  List<Bakery> findFilteredBakeries(
+      @Param("categoryList") List<Category> categoryList,
+      @Param("breadTypeList") List<BreadType> breadTypeList,
+      NutrientType bakeryNutrientType);
 }

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
@@ -10,7 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface MemberNutrientTypeRepository extends JpaRepository<MemberNutrientType, Long> {
   List<MemberNutrientType> findAllByMember(Member member);
 
-  @Query("select mnt from MemberNutrientType mnt where mnt.member.memberId = :memberId")
+  @Query(
+      "select mnt from MemberNutrientType mnt where mnt.member.memberId = :memberId order by mnt.memberNutrientTypeId asc")
   List<MemberNutrientType> findAllByMemberId(Long memberId);
 
   boolean existsByMember(Member member);

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
@@ -3,6 +3,7 @@ package com.org.gunbbang.repository;
 import com.org.gunbbang.entity.Member;
 import com.org.gunbbang.entity.MemberNutrientType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,7 @@ public interface MemberNutrientTypeRepository extends JpaRepository<MemberNutrie
   @Modifying
   @Query("delete from MemberNutrientType mnt where mnt.member=:member")
   void deleteAllByMember(Member member);
+
+  @Query("select mnt from MemberNutrientType mnt where mnt.member.memberId = :memberId")
+  Optional<MemberNutrientType> findByMemberId(Long memberId);
 }

--- a/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
+++ b/storage/db-core/src/main/java/com/org/gunbbang/repository/MemberNutrientTypeRepository.java
@@ -3,7 +3,6 @@ package com.org.gunbbang.repository;
 import com.org.gunbbang.entity.Member;
 import com.org.gunbbang.entity.MemberNutrientType;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,6 +19,7 @@ public interface MemberNutrientTypeRepository extends JpaRepository<MemberNutrie
   @Query("delete from MemberNutrientType mnt where mnt.member=:member")
   void deleteAllByMember(Member member);
 
-  @Query("select mnt from MemberNutrientType mnt where mnt.member.memberId = :memberId")
-  Optional<MemberNutrientType> findByMemberId(Long memberId);
+  @Query(
+      "select mnt from MemberNutrientType mnt where mnt.member.memberId = :memberId order by mnt.memberNutrientTypeId asc")
+  List<MemberNutrientType> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#267 -> dev
- closed #267 

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 건빵집 리스트 기획 요구사항 반영
- 더미데이터의 건빵집이 너무 많아 모든 빵집을 불러와 List에 저장하여 각 일치 개수를 세는 것이라고 생각해 성아언니와 이야기하여 2릴 때 페이지네이션을 도입하여 수정하기로했습니다
- 현재 로직은 카테고리에서 1개 이상 일치 and 빵 유형에서 1개 이상 일치 and 사용자의 영양성분공개 정도와 일치
- 위에 작성한 세가지 조건을 모두 만족해야지만 건빵집이 출력되는 상태입니다
- 기획 더미데이터 마감 후 local에서 50개 이상의 빵집을 넣고 테스트 한번 해봐야할 것 같습니다
- 중요
 - INGREDIENT_OPEN 인 경우 다대다 테이블에 NUTRIENT_OPEN, NOT_OPEN 모두 넣어야함 즉, 관계 테이블에 3개의 컬럼을 생성해야 함
 - NUTRIENT_OPEN인 경우 NOT_OPEN도 관계 테이블에 추가해야함

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![Uploading image.png…]()


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
