### PR TITLE
[FEAT] 필터칩을 선택하지 않은 유저가 건빵집 리스트에서 개인 맞춤 필터를 사용하려고 하는 경우에 대한 예외 처리 구현

### DIFF
--- a/api/src/main/java/com/org/gunbbang/service/BakeryService.java
+++ b/api/src/main/java/com/org/gunbbang/service/BakeryService.java
@@ -54,6 +54,13 @@ public class BakeryService {
     Long memberId = personalFilter ? SecurityUtil.getUserId().orElse(null) : null;
     List<MemberBreadType> memberBreadType =
         personalFilter ? memberBreadTypeRepository.findAllByMemberId(memberId) : null;
+
+    if (memberBreadType.isEmpty()) {
+      throw new NotFoundException(
+          ErrorType.REQUEST_VALIDATION_EXCEPTION,
+          ErrorType.REQUEST_VALIDATION_EXCEPTION.getMessage());
+    }
+
     Page<Bakery> bakeryList =
         getFilteredAndSortedBakeryList(
             personalFilter, memberBreadType, categoryList, sortingOption, memberId, pageRequest);


### PR DESCRIPTION
## 🍞 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🍞 반영 브랜치
<!-- feat/login -> dev와 같이 반영 브랜치를 표시합니다 -->
- feat/#286 -> dev
- closed #286

## 🍞 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 필터칩을 설정하지 않은 유저가 건빵집 리스트 조회에서 개인 맞춤형 필터를 설정하려고 할 경우에 대해 예외처리를 추가했습니다

## 🍞 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="881" alt="스크린샷 2024-02-22 오후 3 02 00" src="https://github.com/GEON-PPANG/GEON-PPANG-SERVER/assets/81363864/c735ede1-5aa9-497c-95a2-faeac2db2304">


## 🍞 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 전반적인 리팩토링이 필요해 보입니다 하하..
